### PR TITLE
feat(core): plugin scaffolding, config module, and entry point

### DIFF
--- a/lua/okuban/config.lua
+++ b/lua/okuban/config.lua
@@ -1,0 +1,84 @@
+local M = {}
+
+---@class OkubanColumn
+---@field label string
+---@field name string
+---@field color string
+
+---@class OkubanKeymaps
+---@field column_left string
+---@field column_right string
+---@field card_up string
+---@field card_down string
+---@field move_card string
+---@field close string
+---@field refresh string
+---@field help string
+
+---@class OkubanClaudeConfig
+---@field enabled boolean
+---@field max_budget_usd number
+---@field max_turns integer
+
+---@class OkubanConfig
+---@field columns OkubanColumn[]
+---@field show_unsorted boolean
+---@field skip_preflight boolean
+---@field github_hostname string|nil
+---@field keymaps OkubanKeymaps
+---@field claude OkubanClaudeConfig
+
+---@type OkubanConfig
+local defaults = {
+  columns = {
+    { label = "okuban:backlog", name = "Backlog", color = "#c5def5" },
+    { label = "okuban:todo", name = "Todo", color = "#0075ca" },
+    { label = "okuban:in-progress", name = "In Progress", color = "#fbca04" },
+    { label = "okuban:review", name = "Review", color = "#d4c5f9" },
+    { label = "okuban:done", name = "Done", color = "#0e8a16" },
+  },
+  show_unsorted = true,
+  skip_preflight = false,
+  github_hostname = nil,
+  keymaps = {
+    column_left = "h",
+    column_right = "l",
+    card_up = "k",
+    card_down = "j",
+    move_card = "m",
+    close = "q",
+    refresh = "r",
+    help = "?",
+  },
+  claude = {
+    enabled = true,
+    max_budget_usd = 5.00,
+    max_turns = 30,
+  },
+}
+
+---@type OkubanConfig
+local config = vim.deepcopy(defaults)
+
+--- Deep merge user options into defaults.
+---@param user_opts table|nil
+function M.setup(user_opts)
+  config = vim.deepcopy(defaults)
+  if user_opts then
+    config = vim.tbl_deep_extend("force", config, user_opts)
+  end
+end
+
+--- Get the current config.
+---@return OkubanConfig
+function M.get()
+  return config
+end
+
+--- Get default config (for tests/reference).
+---@return OkubanConfig
+function M.defaults()
+  return vim.deepcopy(defaults)
+end
+
+return M

--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -1,0 +1,33 @@
+local M = {}
+
+local config = require("okuban.config")
+local utils = require("okuban.utils")
+
+--- Set up okuban with user options.
+---@param opts table|nil
+function M.setup(opts)
+  config.setup(opts)
+end
+
+--- Open the kanban board.
+function M.open()
+  utils.notify("Board opening not yet implemented", vim.log.levels.WARN)
+end
+
+--- Close the kanban board.
+function M.close()
+  utils.notify("Board not open", vim.log.levels.WARN)
+end
+
+--- Refresh the kanban board.
+function M.refresh()
+  utils.notify("Board not open", vim.log.levels.WARN)
+end
+
+--- Run label setup on the current repo.
+---@param opts { full: boolean }
+function M.setup_labels(opts) -- luacheck: no unused args
+  utils.notify("Label setup not yet implemented", vim.log.levels.WARN)
+end
+
+return M

--- a/lua/okuban/utils.lua
+++ b/lua/okuban/utils.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+--- Send a notification with the okuban prefix.
+---@param msg string
+---@param level integer|nil vim.log.levels value (default: INFO)
+function M.notify(msg, level)
+  vim.notify("okuban: " .. msg, level or vim.log.levels.INFO)
+end
+
+--- Check if an executable is available on PATH.
+---@param name string
+---@return boolean
+function M.is_executable(name)
+  return vim.fn.executable(name) == 1
+end
+
+return M

--- a/plugin/okuban.lua
+++ b/plugin/okuban.lua
@@ -1,0 +1,21 @@
+if vim.g.loaded_okuban then
+  return
+end
+vim.g.loaded_okuban = true
+
+vim.api.nvim_create_user_command("Okuban", function()
+  require("okuban").open()
+end, { desc = "Open okuban kanban board" })
+
+vim.api.nvim_create_user_command("OkubanClose", function()
+  require("okuban").close()
+end, { desc = "Close okuban kanban board" })
+
+vim.api.nvim_create_user_command("OkubanRefresh", function()
+  require("okuban").refresh()
+end, { desc = "Refresh okuban kanban board" })
+
+vim.api.nvim_create_user_command("OkubanSetup", function(cmd)
+  local full = cmd.args == "--full"
+  require("okuban").setup_labels({ full = full })
+end, { desc = "Create okuban labels on the repo", nargs = "?" })

--- a/tests/test_config_spec.lua
+++ b/tests/test_config_spec.lua
@@ -1,58 +1,119 @@
--- tests/test_config_spec.lua
--- Basic tests to verify the test harness works and config defaults are sane.
+describe("okuban.config", function()
+  local config
 
-describe("okuban", function()
-  describe("config", function()
-    it("has default columns", function()
-      local defaults = {
-        { label = "okuban:backlog", name = "Backlog", color = "#c5def5" },
-        { label = "okuban:todo", name = "Todo", color = "#0075ca" },
-        { label = "okuban:in-progress", name = "In Progress", color = "#fbca04" },
-        { label = "okuban:review", name = "Review", color = "#d4c5f9" },
-        { label = "okuban:done", name = "Done", color = "#0e8a16" },
-      }
-      assert.equals(5, #defaults)
-      assert.equals("okuban:backlog", defaults[1].label)
-      assert.equals("okuban:done", defaults[5].label)
-    end)
-
-    it("has show_unsorted enabled by default", function()
-      local defaults = { show_unsorted = true }
-      assert.is_true(defaults.show_unsorted)
-    end)
-
-    it("has skip_preflight disabled by default", function()
-      local defaults = { skip_preflight = false }
-      assert.is_false(defaults.skip_preflight)
-    end)
-
-    it("has claude settings with sane defaults", function()
-      local defaults = {
-        claude = {
-          enabled = true,
-          max_budget_usd = 5.00,
-          max_turns = 30,
-        },
-      }
-      assert.is_true(defaults.claude.enabled)
-      assert.equals(5.00, defaults.claude.max_budget_usd)
-      assert.equals(30, defaults.claude.max_turns)
-    end)
+  before_each(function()
+    package.loaded["okuban.config"] = nil
+    config = require("okuban.config")
   end)
 
-  describe("label system", function()
-    it("uses okuban: prefix for all kanban labels", function()
-      local labels = { "okuban:backlog", "okuban:todo", "okuban:in-progress", "okuban:review", "okuban:done" }
-      for _, label in ipairs(labels) do
-        assert.truthy(label:match("^okuban:"))
-      end
+  describe("defaults", function()
+    it("has 5 kanban columns", function()
+      local cfg = config.get()
+      assert.equals(5, #cfg.columns)
+    end)
+
+    it("has correct column labels", function()
+      local cfg = config.get()
+      assert.equals("okuban:backlog", cfg.columns[1].label)
+      assert.equals("okuban:todo", cfg.columns[2].label)
+      assert.equals("okuban:in-progress", cfg.columns[3].label)
+      assert.equals("okuban:review", cfg.columns[4].label)
+      assert.equals("okuban:done", cfg.columns[5].label)
+    end)
+
+    it("has correct column names", function()
+      local cfg = config.get()
+      assert.equals("Backlog", cfg.columns[1].name)
+      assert.equals("In Progress", cfg.columns[3].name)
+      assert.equals("Done", cfg.columns[5].name)
     end)
 
     it("has valid hex colors for all columns", function()
-      local colors = { "#c5def5", "#0075ca", "#fbca04", "#d4c5f9", "#0e8a16" }
-      for _, color in ipairs(colors) do
-        assert.truthy(color:match("^#%x%x%x%x%x%x$"), "Invalid hex color: " .. color)
+      local cfg = config.get()
+      for _, col in ipairs(cfg.columns) do
+        assert.truthy(col.color:match("^#%x%x%x%x%x%x$"), "Invalid hex color: " .. col.color)
       end
+    end)
+
+    it("uses okuban: prefix for all kanban labels", function()
+      local cfg = config.get()
+      for _, col in ipairs(cfg.columns) do
+        assert.truthy(col.label:match("^okuban:"), "Missing prefix: " .. col.label)
+      end
+    end)
+
+    it("has show_unsorted enabled", function()
+      assert.is_true(config.get().show_unsorted)
+    end)
+
+    it("has skip_preflight disabled", function()
+      assert.is_false(config.get().skip_preflight)
+    end)
+
+    it("has nil github_hostname", function()
+      assert.is_nil(config.get().github_hostname)
+    end)
+
+    it("has claude settings with sane defaults", function()
+      local claude = config.get().claude
+      assert.is_true(claude.enabled)
+      assert.equals(5.00, claude.max_budget_usd)
+      assert.equals(30, claude.max_turns)
+    end)
+
+    it("has default keymaps", function()
+      local keymaps = config.get().keymaps
+      assert.equals("h", keymaps.column_left)
+      assert.equals("l", keymaps.column_right)
+      assert.equals("k", keymaps.card_up)
+      assert.equals("j", keymaps.card_down)
+      assert.equals("m", keymaps.move_card)
+      assert.equals("q", keymaps.close)
+      assert.equals("r", keymaps.refresh)
+      assert.equals("?", keymaps.help)
+    end)
+  end)
+
+  describe("setup", function()
+    it("merges user overrides", function()
+      config.setup({ show_unsorted = false })
+      assert.is_false(config.get().show_unsorted)
+    end)
+
+    it("preserves defaults for unset keys", function()
+      config.setup({ show_unsorted = false })
+      assert.equals(5, #config.get().columns)
+      assert.is_true(config.get().claude.enabled)
+    end)
+
+    it("deep merges nested tables", function()
+      config.setup({ claude = { max_turns = 50 } })
+      local claude = config.get().claude
+      assert.equals(50, claude.max_turns)
+      assert.equals(5.00, claude.max_budget_usd)
+      assert.is_true(claude.enabled)
+    end)
+
+    it("allows keymap overrides", function()
+      config.setup({ keymaps = { close = "<Esc>" } })
+      local keymaps = config.get().keymaps
+      assert.equals("<Esc>", keymaps.close)
+      assert.equals("h", keymaps.column_left)
+    end)
+
+    it("resets to defaults on each setup call", function()
+      config.setup({ show_unsorted = false })
+      assert.is_false(config.get().show_unsorted)
+      config.setup({})
+      assert.is_true(config.get().show_unsorted)
+    end)
+  end)
+
+  describe("defaults()", function()
+    it("returns a copy that does not mutate internal state", function()
+      local d = config.defaults()
+      d.show_unsorted = false
+      assert.is_true(config.get().show_unsorted)
     end)
   end)
 end)


### PR DESCRIPTION
## Summary
- Plugin entry point with `setup()`, command registration (`:Okuban`, `:OkubanSetup`, `:OkubanRefresh`, `:OkubanClose`)
- Config module with defaults (5 columns, keymaps, claude settings), deep merge, `get()` accessor
- Utils module with `notify()` wrapper and `is_executable()` helper
- 16 passing tests covering defaults, merge behavior, keymap overrides, and immutability

## Test plan
- [x] `make test` passes (16 tests)
- [x] `make lint` passes (StyLua + Luacheck)
- [x] Plugin loads cleanly in headless Neovim
- [x] `:Okuban` command registered and callable

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)