### PR TITLE
feat(api): preflight checks for gh CLI authentication and repo access

### DIFF
--- a/lua/okuban/api.lua
+++ b/lua/okuban/api.lua
@@ -1,0 +1,113 @@
+local config = require("okuban.config")
+local utils = require("okuban.utils")
+
+local M = {}
+
+--- Session-level cache for preflight results.
+local preflight_passed = false
+
+--- Build the gh command prefix, respecting github_hostname config.
+---@return string[]
+local function gh_base_cmd()
+  local hostname = config.get().github_hostname
+  if hostname then
+    return { "gh", "--hostname", hostname }
+  end
+  return { "gh" }
+end
+
+--- Check if gh CLI is installed (synchronous).
+---@return boolean
+function M.check_gh_installed()
+  return utils.is_executable("gh")
+end
+
+--- Check if gh CLI is authenticated.
+---@param callback fun(ok: boolean, err: string|nil)
+function M.check_gh_auth(callback)
+  local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), { "auth", "status" })
+  vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      if result.code == 0 then
+        callback(true, nil)
+      else
+        callback(false, "Not authenticated. Run: gh auth login")
+      end
+    end)
+  end)
+end
+
+--- Check if we have repo access in the current directory.
+---@param callback fun(ok: boolean, err: string|nil)
+function M.check_repo_access(callback)
+  local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), { "repo", "view", "--json", "name", "-q", ".name" })
+  vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      if result.code == 0 and result.stdout and result.stdout:match("%S") then
+        callback(true, nil)
+      else
+        local msg = "Cannot access repository. Ensure you are in a git repo with a GitHub remote"
+        if result.stderr and result.stderr:match("scope") then
+          msg = "Insufficient GitHub permissions. Run: gh auth refresh -s repo"
+        end
+        callback(false, msg)
+      end
+    end)
+  end)
+end
+
+--- Run all preflight checks in sequence.
+--- Calls callback(true) on success, or notifies error and calls callback(false).
+---@param callback fun(ok: boolean)
+function M.preflight(callback)
+  if config.get().skip_preflight then
+    callback(true)
+    return
+  end
+
+  if preflight_passed then
+    callback(true)
+    return
+  end
+
+  -- Step 1: gh installed (sync)
+  if not M.check_gh_installed() then
+    utils.notify("gh CLI not found. Install from https://cli.github.com", vim.log.levels.ERROR)
+    callback(false)
+    return
+  end
+
+  -- Step 2: gh authenticated (async)
+  M.check_gh_auth(function(ok, err)
+    if not ok then
+      utils.notify(err, vim.log.levels.ERROR)
+      callback(false)
+      return
+    end
+
+    -- Step 3: repo access (async)
+    M.check_repo_access(function(repo_ok, repo_err)
+      if not repo_ok then
+        utils.notify(repo_err, vim.log.levels.ERROR)
+        callback(false)
+        return
+      end
+
+      preflight_passed = true
+      callback(true)
+    end)
+  end)
+end
+
+--- Reset preflight cache (for testing).
+function M._reset_preflight()
+  preflight_passed = false
+end
+
+--- Expose gh_base_cmd for other api functions.
+---@return string[]
+function M._gh_base_cmd()
+  return gh_base_cmd()
+end
+
+return M

--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local config = require("okuban.config")
 local utils = require("okuban.utils")
+local api = require("okuban.api")
 
 --- Set up okuban with user options.
 ---@param opts table|nil
@@ -11,7 +12,12 @@ end
 
 --- Open the kanban board.
 function M.open()
-  utils.notify("Board opening not yet implemented", vim.log.levels.WARN)
+  api.preflight(function(ok)
+    if not ok then
+      return
+    end
+    utils.notify("Board opening not yet implemented", vim.log.levels.WARN)
+  end)
 end
 
 --- Close the kanban board.

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,0 +1,44 @@
+local M = {}
+
+local original_vim_system = vim.system
+
+--- Mock vim.system() with predefined responses.
+--- Responses are matched in order. Each call consumes the next response.
+---@param responses table[] List of { code, stdout, stderr } tables
+function M.mock_vim_system(responses)
+  local call_idx = 0
+  local calls = {}
+
+  vim.system = function(cmd, opts, on_exit)
+    call_idx = call_idx + 1
+    table.insert(calls, { cmd = cmd, opts = opts })
+    local resp = responses[call_idx] or { code = 1, stdout = "", stderr = "unexpected call #" .. call_idx }
+
+    local result = {
+      code = resp.code or 0,
+      stdout = resp.stdout or "",
+      stderr = resp.stderr or "",
+    }
+
+    if on_exit then
+      vim.schedule(function()
+        on_exit(result)
+      end)
+    end
+
+    return {
+      wait = function()
+        return result
+      end,
+    }
+  end
+
+  return calls
+end
+
+--- Restore the original vim.system().
+function M.restore_vim_system()
+  vim.system = original_vim_system
+end
+
+return M

--- a/tests/test_api_spec.lua
+++ b/tests/test_api_spec.lua
@@ -1,0 +1,217 @@
+local helpers = require("tests.helpers")
+
+describe("okuban.api", function()
+  local api, config
+
+  before_each(function()
+    package.loaded["okuban.api"] = nil
+    package.loaded["okuban.config"] = nil
+    config = require("okuban.config")
+    api = require("okuban.api")
+    api._reset_preflight()
+  end)
+
+  after_each(function()
+    helpers.restore_vim_system()
+  end)
+
+  describe("check_gh_installed", function()
+    it("returns true when gh is on PATH", function()
+      -- gh is installed in CI and dev environments
+      -- This is a real check, not mocked
+      local result = api.check_gh_installed()
+      assert.is_true(result)
+    end)
+  end)
+
+  describe("check_gh_auth", function()
+    it("calls callback with true when authenticated", function()
+      helpers.mock_vim_system({
+        { code = 0, stdout = "Logged in to github.com" },
+      })
+
+      local done = false
+      local success = false
+      api.check_gh_auth(function(ok)
+        done = true
+        success = ok
+      end)
+
+      -- Force scheduled callbacks to run
+      vim.wait(1000, function()
+        return done
+      end)
+      assert.is_true(success)
+    end)
+
+    it("calls callback with false when not authenticated", function()
+      helpers.mock_vim_system({
+        { code = 1, stderr = "not logged in" },
+      })
+
+      local done = false
+      local success = true
+      local err_msg = nil
+      api.check_gh_auth(function(ok, err)
+        done = true
+        success = ok
+        err_msg = err
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+      assert.is_false(success)
+      assert.truthy(err_msg:match("gh auth login"))
+    end)
+  end)
+
+  describe("check_repo_access", function()
+    it("calls callback with true when repo is accessible", function()
+      helpers.mock_vim_system({
+        { code = 0, stdout = "okuban.nvim\n" },
+      })
+
+      local done = false
+      local success = false
+      api.check_repo_access(function(ok)
+        done = true
+        success = ok
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+      assert.is_true(success)
+    end)
+
+    it("calls callback with false when repo is not accessible", function()
+      helpers.mock_vim_system({
+        { code = 1, stderr = "not a git repository" },
+      })
+
+      local done = false
+      local success = true
+      api.check_repo_access(function(ok)
+        done = true
+        success = ok
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+      assert.is_false(success)
+    end)
+  end)
+
+  describe("preflight", function()
+    it("skips all checks when skip_preflight is true", function()
+      config.setup({ skip_preflight = true })
+      -- Re-require api to pick up new config
+      package.loaded["okuban.api"] = nil
+      api = require("okuban.api")
+
+      local done = false
+      local success = false
+      api.preflight(function(ok)
+        done = true
+        success = ok
+      end)
+
+      -- skip_preflight is synchronous, no need for vim.wait
+      assert.is_true(done)
+      assert.is_true(success)
+    end)
+
+    it("caches results after first successful preflight", function()
+      local calls = helpers.mock_vim_system({
+        { code = 0, stdout = "Logged in" }, -- auth check
+        { code = 0, stdout = "okuban.nvim\n" }, -- repo check
+      })
+
+      local done = false
+      api.preflight(function(ok)
+        done = true
+        assert.is_true(ok)
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+
+      -- Second call should not trigger any vim.system calls
+      local done2 = false
+      api.preflight(function(ok)
+        done2 = true
+        assert.is_true(ok)
+      end)
+
+      assert.is_true(done2)
+      assert.equals(2, #calls) -- only 2 calls total, not 4
+    end)
+
+    it("runs auth and repo checks in sequence", function()
+      local calls = helpers.mock_vim_system({
+        { code = 0, stdout = "Logged in" }, -- auth
+        { code = 0, stdout = "okuban.nvim\n" }, -- repo
+      })
+
+      local done = false
+      api.preflight(function(ok)
+        done = true
+        assert.is_true(ok)
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+
+      assert.equals(2, #calls)
+      -- First call should be auth status
+      assert.truthy(vim.tbl_contains(calls[1].cmd, "auth"))
+      -- Second call should be repo view
+      assert.truthy(vim.tbl_contains(calls[2].cmd, "repo"))
+    end)
+
+    it("stops on auth failure without checking repo", function()
+      local calls = helpers.mock_vim_system({
+        { code = 1, stderr = "not logged in" }, -- auth fails
+      })
+
+      local done = false
+      api.preflight(function(ok)
+        done = true
+        assert.is_false(ok)
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+
+      assert.equals(1, #calls) -- only auth was called
+    end)
+  end)
+
+  describe("github_hostname", function()
+    it("includes hostname in gh commands when configured", function()
+      config.setup({ github_hostname = "github.example.com" })
+      package.loaded["okuban.api"] = nil
+      api = require("okuban.api")
+
+      local cmd = api._gh_base_cmd()
+      assert.equals("gh", cmd[1])
+      assert.equals("--hostname", cmd[2])
+      assert.equals("github.example.com", cmd[3])
+    end)
+
+    it("uses plain gh when no hostname configured", function()
+      config.setup({})
+      package.loaded["okuban.api"] = nil
+      api = require("okuban.api")
+
+      local cmd = api._gh_base_cmd()
+      assert.equals(1, #cmd)
+      assert.equals("gh", cmd[1])
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Preflight checks: gh installed, authenticated, repo access — all with actionable error messages
- Session-level caching (no re-run on second `:Okuban`)
- GitHub Enterprise hostname support via `config.github_hostname`
- Test helpers with `mock_vim_system()` for all future API tests
- 11 new tests (27 total)

## Test plan
- [x] `make test` passes (27 tests)
- [x] `make lint` passes
- [x] Missing gh → error with install URL
- [x] Unauthenticated → error with fix command
- [x] No repo access → error with context
- [x] skip_preflight bypasses all checks
- [x] Results cached within session

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)