### PR TITLE
feat(api): fetch issues per label and OkubanSetup label creation

### DIFF
--- a/lua/okuban/api.lua
+++ b/lua/okuban/api.lua
@@ -110,4 +110,225 @@ function M._gh_base_cmd()
   return gh_base_cmd()
 end
 
+-- ---------------------------------------------------------------------------
+-- Fetch issues
+-- ---------------------------------------------------------------------------
+
+local ISSUE_FIELDS = "number,title,assignees,labels,state"
+
+--- Fetch issues for a single label.
+---@param label string The label to filter by
+---@param callback fun(issues: table[]|nil, err: string|nil)
+function M.fetch_column(label, callback)
+  local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), {
+    "issue",
+    "list",
+    "--label",
+    label,
+    "--json",
+    ISSUE_FIELDS,
+    "--limit",
+    "100",
+    "--state",
+    "open",
+  })
+  vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        callback(nil, "Failed to fetch issues for " .. label .. ": " .. (result.stderr or ""))
+        return
+      end
+      local ok, issues = pcall(vim.json.decode, result.stdout)
+      if not ok or type(issues) ~= "table" then
+        callback({}, nil)
+        return
+      end
+      callback(issues, nil)
+    end)
+  end)
+end
+
+--- Fetch unsorted issues (open issues without any okuban: label).
+---@param columns table[] The configured columns
+---@param callback fun(issues: table[]|nil, err: string|nil)
+function M.fetch_unsorted(columns, callback)
+  local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), {
+    "issue",
+    "list",
+    "--json",
+    ISSUE_FIELDS,
+    "--limit",
+    "100",
+    "--state",
+    "open",
+  })
+  vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        callback(nil, "Failed to fetch issues: " .. (result.stderr or ""))
+        return
+      end
+      local ok, all_issues = pcall(vim.json.decode, result.stdout)
+      if not ok or type(all_issues) ~= "table" then
+        callback({}, nil)
+        return
+      end
+
+      -- Build a set of kanban labels for fast lookup
+      local kanban_labels = {}
+      for _, col in ipairs(columns) do
+        kanban_labels[col.label] = true
+      end
+
+      -- Filter: only keep issues that have NO okuban: label
+      local unsorted = {}
+      for _, issue in ipairs(all_issues) do
+        local has_kanban = false
+        if issue.labels then
+          for _, lbl in ipairs(issue.labels) do
+            if kanban_labels[lbl.name] then
+              has_kanban = true
+              break
+            end
+          end
+        end
+        if not has_kanban then
+          table.insert(unsorted, issue)
+        end
+      end
+
+      callback(unsorted, nil)
+    end)
+  end)
+end
+
+--- Fetch all columns in parallel and return structured board data.
+---@param callback fun(data: table|nil)
+function M.fetch_all_columns(callback)
+  local cfg = config.get()
+  local columns = cfg.columns
+  local total = #columns + (cfg.show_unsorted and 1 or 0)
+  local pending = total
+  local results = {}
+
+  local function on_done()
+    pending = pending - 1
+    if pending == 0 then
+      -- Build ordered result
+      local board_data = { columns = {} }
+      for _, col in ipairs(columns) do
+        table.insert(board_data.columns, {
+          label = col.label,
+          name = col.name,
+          color = col.color,
+          issues = results[col.label] or {},
+        })
+      end
+      if cfg.show_unsorted then
+        board_data.unsorted = results["_unsorted"] or {}
+      end
+      callback(board_data)
+    end
+  end
+
+  -- Fire all column fetches in parallel
+  for _, col in ipairs(columns) do
+    M.fetch_column(col.label, function(issues, err)
+      if err then
+        utils.notify(err, vim.log.levels.WARN)
+      end
+      results[col.label] = issues or {}
+      on_done()
+    end)
+  end
+
+  -- Fetch unsorted if enabled
+  if cfg.show_unsorted then
+    M.fetch_unsorted(columns, function(issues, err)
+      if err then
+        utils.notify(err, vim.log.levels.WARN)
+      end
+      results["_unsorted"] = issues or {}
+      on_done()
+    end)
+  end
+end
+
+-- ---------------------------------------------------------------------------
+-- Label management
+-- ---------------------------------------------------------------------------
+
+--- All labels that can be created by OkubanSetup.
+local kanban_labels = {
+  { name = "okuban:backlog", color = "c5def5", description = "Kanban: Not yet planned" },
+  { name = "okuban:todo", color = "0075ca", description = "Kanban: Planned for work" },
+  { name = "okuban:in-progress", color = "fbca04", description = "Kanban: Actively being worked on" },
+  { name = "okuban:review", color = "d4c5f9", description = "Kanban: Awaiting review" },
+  { name = "okuban:done", color = "0e8a16", description = "Kanban: Completed" },
+}
+
+local full_labels = {
+  { name = "type: bug", color = "d73a4a", description = "Something is not working" },
+  { name = "type: feature", color = "0075ca", description = "New functionality" },
+  { name = "type: docs", color = "fef2c0", description = "Documentation improvement" },
+  { name = "type: chore", color = "e6e6e6", description = "Maintenance, refactoring, CI" },
+  { name = "priority: critical", color = "d73a4a", description = "Drop everything" },
+  { name = "priority: high", color = "d93f0b", description = "Do this cycle" },
+  { name = "priority: medium", color = "fbca04", description = "Important but not urgent" },
+  { name = "priority: low", color = "0e8a16", description = "Backlog / nice-to-have" },
+  { name = "good first issue", color = "7057ff", description = "Good for newcomers" },
+  { name = "help wanted", color = "008672", description = "Maintainer seeks help" },
+  { name = "needs: triage", color = "fbca04", description = "Needs initial assessment" },
+  { name = "needs: repro", color = "fbca04", description = "Needs reproduction steps" },
+}
+
+--- Create a single label on the repo (idempotent via --force).
+---@param label table { name, color, description }
+---@param callback fun(ok: boolean)
+function M.create_label(label, callback)
+  local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), {
+    "label",
+    "create",
+    label.name,
+    "--color",
+    label.color,
+    "--description",
+    label.description,
+    "--force",
+  })
+  vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      callback(result.code == 0)
+    end)
+  end)
+end
+
+--- Create all labels for OkubanSetup.
+---@param full boolean If true, create all labels including type/priority/community
+---@param callback fun(created: integer, failed: integer)
+function M.create_all_labels(full, callback)
+  local labels = vim.deepcopy(kanban_labels)
+  if full then
+    vim.list_extend(labels, full_labels)
+  end
+
+  local pending = #labels
+  local created = 0
+  local failed = 0
+
+  for _, label in ipairs(labels) do
+    M.create_label(label, function(ok)
+      if ok then
+        created = created + 1
+      else
+        failed = failed + 1
+      end
+      pending = pending - 1
+      if pending == 0 then
+        callback(created, failed)
+      end
+    end)
+  end
+end
+
 return M

--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -32,8 +32,21 @@ end
 
 --- Run label setup on the current repo.
 ---@param opts { full: boolean }
-function M.setup_labels(opts) -- luacheck: no unused args
-  utils.notify("Label setup not yet implemented", vim.log.levels.WARN)
+function M.setup_labels(opts)
+  api.preflight(function(ok)
+    if not ok then
+      return
+    end
+    local full = opts and opts.full or false
+    utils.notify("Creating labels" .. (full and " (full set)" or "") .. "...")
+    api.create_all_labels(full, function(created, failed)
+      if failed > 0 then
+        utils.notify(string.format("Created %d labels, %d failed", created, failed), vim.log.levels.WARN)
+      else
+        utils.notify(string.format("Created %d labels", created))
+      end
+    end)
+  end)
 end
 
 return M

--- a/tests/test_api_fetch_spec.lua
+++ b/tests/test_api_fetch_spec.lua
@@ -1,0 +1,258 @@
+local helpers = require("tests.helpers")
+
+describe("okuban.api fetch", function()
+  local api, config
+
+  before_each(function()
+    package.loaded["okuban.api"] = nil
+    package.loaded["okuban.config"] = nil
+    config = require("okuban.config")
+    api = require("okuban.api")
+  end)
+
+  after_each(function()
+    helpers.restore_vim_system()
+  end)
+
+  describe("fetch_column", function()
+    it("parses JSON response into issue list", function()
+      local json = vim.json.encode({
+        {
+          number = 42,
+          title = "Add board rendering",
+          assignees = { { login = "alice" } },
+          labels = {},
+          state = "OPEN",
+        },
+        { number = 43, title = "Fix navigation", assignees = {}, labels = {}, state = "OPEN" },
+      })
+      helpers.mock_vim_system({
+        { code = 0, stdout = json },
+      })
+
+      local done = false
+      local result = nil
+      api.fetch_column("okuban:todo", function(issues)
+        done = true
+        result = issues
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+      assert.equals(2, #result)
+      assert.equals(42, result[1].number)
+      assert.equals("Add board rendering", result[1].title)
+      assert.equals(43, result[2].number)
+    end)
+
+    it("returns empty list on JSON parse error", function()
+      helpers.mock_vim_system({
+        { code = 0, stdout = "not valid json{{{" },
+      })
+
+      local done = false
+      local result = nil
+      api.fetch_column("okuban:todo", function(issues)
+        done = true
+        result = issues
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+      assert.equals(0, #result)
+    end)
+
+    it("returns nil with error on command failure", function()
+      helpers.mock_vim_system({
+        { code = 1, stderr = "network error" },
+      })
+
+      local done = false
+      local result_issues = "not_nil"
+      local result_err = nil
+      api.fetch_column("okuban:todo", function(issues, err)
+        done = true
+        result_issues = issues
+        result_err = err
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+      assert.is_nil(result_issues)
+      assert.truthy(result_err)
+    end)
+
+    it("includes correct gh command arguments", function()
+      local calls = helpers.mock_vim_system({
+        { code = 0, stdout = "[]" },
+      })
+
+      local done = false
+      api.fetch_column("okuban:in-progress", function()
+        done = true
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+
+      local cmd = calls[1].cmd
+      assert.truthy(vim.tbl_contains(cmd, "issue"))
+      assert.truthy(vim.tbl_contains(cmd, "list"))
+      assert.truthy(vim.tbl_contains(cmd, "--label"))
+      assert.truthy(vim.tbl_contains(cmd, "okuban:in-progress"))
+      assert.truthy(vim.tbl_contains(cmd, "--json"))
+      assert.truthy(vim.tbl_contains(cmd, "--limit"))
+      assert.truthy(vim.tbl_contains(cmd, "100"))
+    end)
+  end)
+
+  describe("fetch_all_columns", function()
+    it("returns structured board data with all columns", function()
+      -- Mock responses for 5 columns + 1 unsorted fetch = 6 calls
+      local responses = {}
+      for i = 1, 5 do
+        responses[i] = { code = 0, stdout = "[]" }
+      end
+      -- Column 2 (todo) has an issue
+      responses[2] = {
+        code = 0,
+        stdout = vim.json.encode({
+          { number = 10, title = "Test issue", assignees = {}, labels = {}, state = "OPEN" },
+        }),
+      }
+      -- Unsorted fetch (all issues) returns one issue without kanban labels
+      responses[6] = {
+        code = 0,
+        stdout = vim.json.encode({
+          { number = 10, title = "Test issue", assignees = {}, labels = { { name = "okuban:todo" } }, state = "OPEN" },
+          { number = 99, title = "Unsorted issue", assignees = {}, labels = { { name = "bug" } }, state = "OPEN" },
+        }),
+      }
+      helpers.mock_vim_system(responses)
+
+      local done = false
+      local result = nil
+      api.fetch_all_columns(function(data)
+        done = true
+        result = data
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      assert.is_not_nil(result)
+      assert.equals(5, #result.columns)
+      assert.equals("Backlog", result.columns[1].name)
+      assert.equals("Todo", result.columns[2].name)
+      assert.equals(1, #result.columns[2].issues)
+      assert.equals(10, result.columns[2].issues[1].number)
+      assert.is_not_nil(result.unsorted)
+      assert.equals(1, #result.unsorted)
+      assert.equals(99, result.unsorted[1].number)
+    end)
+
+    it("excludes unsorted when show_unsorted is false", function()
+      config.setup({ show_unsorted = false })
+      package.loaded["okuban.api"] = nil
+      api = require("okuban.api")
+
+      local responses = {}
+      for i = 1, 5 do
+        responses[i] = { code = 0, stdout = "[]" }
+      end
+      local calls = helpers.mock_vim_system(responses)
+
+      local done = false
+      local result = nil
+      api.fetch_all_columns(function(data)
+        done = true
+        result = data
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      assert.equals(5, #result.columns)
+      assert.is_nil(result.unsorted)
+      assert.equals(5, #calls) -- only 5 calls, no unsorted fetch
+    end)
+  end)
+
+  describe("create_all_labels", function()
+    it("creates 5 kanban labels by default", function()
+      local responses = {}
+      for i = 1, 5 do
+        responses[i] = { code = 0 }
+      end
+      local calls = helpers.mock_vim_system(responses)
+
+      local done = false
+      local created_count = 0
+      api.create_all_labels(false, function(created, failed)
+        done = true
+        created_count = created
+        assert.equals(0, failed)
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      assert.equals(5, #calls)
+      assert.equals(5, created_count)
+      -- Verify first label command
+      assert.truthy(vim.tbl_contains(calls[1].cmd, "label"))
+      assert.truthy(vim.tbl_contains(calls[1].cmd, "create"))
+      assert.truthy(vim.tbl_contains(calls[1].cmd, "--force"))
+    end)
+
+    it("creates all ~17 labels when full is true", function()
+      local responses = {}
+      for i = 1, 17 do
+        responses[i] = { code = 0 }
+      end
+      local calls = helpers.mock_vim_system(responses)
+
+      local done = false
+      local created_count = 0
+      api.create_all_labels(true, function(created, failed)
+        done = true
+        created_count = created
+        assert.equals(0, failed)
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      assert.equals(17, #calls)
+      assert.equals(17, created_count)
+    end)
+
+    it("reports failures correctly", function()
+      local responses = {}
+      for i = 1, 5 do
+        responses[i] = { code = 0 }
+      end
+      responses[3] = { code = 1, stderr = "permission denied" }
+      helpers.mock_vim_system(responses)
+
+      local done = false
+      api.create_all_labels(false, function(created, failed)
+        done = true
+        assert.equals(4, created)
+        assert.equals(1, failed)
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Parallel issue fetching per label column with atomic counter pattern
- Unsorted issue filtering (issues without any `okuban:` label)
- Structured board data returned to UI layer
- `:OkubanSetup` creates 5 kanban labels, `--full` creates all 17
- Idempotent label creation via `--force` flag
- 9 new tests (36 total)

## Test plan
- [x] `make test` passes (36 tests)
- [x] `make lint` passes
- [x] JSON parse errors handled gracefully
- [x] Command failures return nil with error message
- [x] Label creation reports successes and failures

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)