### PR TITLE
feat(ui): multi-column floating window layout with card rendering

### DIFF
--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -12,22 +12,50 @@ end
 
 --- Open the kanban board.
 function M.open()
+  local Board = require("okuban.ui.board")
+  local board = Board.get_instance()
+
+  -- If board is already open, close it first (toggle behavior)
+  if board:is_open() then
+    board:close()
+    return
+  end
+
   api.preflight(function(ok)
     if not ok then
       return
     end
-    utils.notify("Board opening not yet implemented", vim.log.levels.WARN)
+    api.fetch_all_columns(function(data)
+      if not data then
+        utils.notify("Failed to fetch issues", vim.log.levels.ERROR)
+        return
+      end
+      board:open(data)
+    end)
   end)
 end
 
 --- Close the kanban board.
 function M.close()
-  utils.notify("Board not open", vim.log.levels.WARN)
+  local Board = require("okuban.ui.board")
+  Board.close_instance()
 end
 
 --- Refresh the kanban board.
 function M.refresh()
-  utils.notify("Board not open", vim.log.levels.WARN)
+  local Board = require("okuban.ui.board")
+  local board = Board.get_instance()
+  if not board:is_open() then
+    utils.notify("Board not open", vim.log.levels.WARN)
+    return
+  end
+  api.fetch_all_columns(function(data)
+    if not data then
+      utils.notify("Failed to refresh", vim.log.levels.ERROR)
+      return
+    end
+    board:refresh(data)
+  end)
 end
 
 --- Run label setup on the current repo.

--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -1,0 +1,236 @@
+local card = require("okuban.ui.card")
+local utils = require("okuban.utils")
+
+local Board = {}
+Board.__index = Board
+
+-- Singleton instance
+local instance = nil
+
+--- Highlight groups with sensible defaults.
+local function define_highlights()
+  vim.api.nvim_set_hl(0, "OkubanCardFocused", { default = true, link = "CursorLine" })
+  vim.api.nvim_set_hl(0, "OkubanColumnHeader", { default = true, link = "Title" })
+end
+
+--- Calculate layout dimensions for the board.
+---@param num_cols integer
+---@param screen_width integer|nil
+---@param screen_height integer|nil
+---@return table { board_width, board_height, col_width, start_row, start_col, gap }
+function Board.calculate_layout(num_cols, screen_width, screen_height)
+  local sw = screen_width or vim.o.columns
+  local sh = screen_height or vim.o.lines
+
+  local board_width = math.floor(sw * 0.9)
+  local board_height = math.floor(sh * 0.8)
+  local gap = 1
+  local col_width = math.floor((board_width - (num_cols - 1) * gap) / num_cols)
+
+  -- Enforce minimum column width
+  local min_col_width = 20
+  if col_width < min_col_width then
+    col_width = min_col_width
+    board_width = num_cols * col_width + (num_cols - 1) * gap
+  end
+
+  local start_row = math.floor((sh - board_height) / 2)
+  local start_col = math.floor((sw - board_width) / 2)
+
+  return {
+    board_width = board_width,
+    board_height = board_height,
+    col_width = col_width,
+    start_row = start_row,
+    start_col = start_col,
+    gap = gap,
+  }
+end
+
+--- Create a new Board instance.
+---@return table
+function Board.new()
+  local o = setmetatable({}, Board)
+  o.windows = {}
+  o.buffers = {}
+  o.data = nil
+  o.augroup = nil
+  return o
+end
+
+--- Open the board with the given data.
+---@param data table Board data from api.fetch_all_columns
+function Board:open(data)
+  self.data = data
+  define_highlights()
+
+  -- Build the column list for rendering
+  local cols = {}
+  for _, col in ipairs(data.columns) do
+    table.insert(cols, { name = col.name, issues = col.issues })
+  end
+  if data.unsorted and #data.unsorted > 0 then
+    table.insert(cols, { name = "Unsorted", issues = data.unsorted })
+  end
+
+  if #cols == 0 then
+    utils.notify("No columns to display", vim.log.levels.WARN)
+    return
+  end
+
+  local layout = Board.calculate_layout(#cols)
+
+  -- Create autocommand group for this board
+  self.augroup = vim.api.nvim_create_augroup("OkubanBoard", { clear = true })
+
+  -- Create one floating window per column
+  for i, col in ipairs(cols) do
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.bo[buf].buftype = "nofile"
+    vim.bo[buf].bufhidden = "wipe"
+    vim.bo[buf].swapfile = false
+    vim.bo[buf].filetype = "okuban"
+
+    -- Render cards into the buffer
+    local inner_width = layout.col_width - 2 -- account for border
+    local lines = card.render_column(col.issues, inner_width)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    vim.bo[buf].modifiable = false
+
+    -- Calculate window position
+    local col_offset = (i - 1) * (layout.col_width + layout.gap)
+    local win_col = layout.start_col + col_offset
+
+    local title = string.format(" %s (%d) ", col.name, #col.issues)
+    local win = vim.api.nvim_open_win(buf, i == 1, {
+      relative = "editor",
+      row = layout.start_row,
+      col = win_col,
+      width = layout.col_width,
+      height = layout.board_height,
+      style = "minimal",
+      border = "rounded",
+      title = title,
+      title_pos = "center",
+      focusable = true,
+      zindex = 50,
+    })
+
+    -- Set window options
+    vim.wo[win].cursorline = false
+    vim.wo[win].wrap = false
+    vim.wo[win].number = false
+    vim.wo[win].relativenumber = false
+    vim.wo[win].signcolumn = "no"
+
+    table.insert(self.windows, win)
+    table.insert(self.buffers, buf)
+  end
+
+  -- Store column metadata for navigation
+  self.columns = cols
+
+  -- VimResized handler
+  vim.api.nvim_create_autocmd("VimResized", {
+    group = self.augroup,
+    callback = function()
+      self:_reposition()
+    end,
+  })
+
+  -- WinClosed handler — if any board window is closed externally, clean up all
+  vim.api.nvim_create_autocmd("WinClosed", {
+    group = self.augroup,
+    callback = function(ev)
+      local closed_win = tonumber(ev.match)
+      for _, w in ipairs(self.windows) do
+        if w == closed_win then
+          -- Defer to avoid issues during WinClosed
+          vim.schedule(function()
+            self:close()
+          end)
+          return
+        end
+      end
+    end,
+  })
+end
+
+--- Reposition all windows after a resize.
+function Board:_reposition()
+  if #self.windows == 0 then
+    return
+  end
+
+  local num_cols = #self.windows
+  local layout = Board.calculate_layout(num_cols)
+
+  for i, win in ipairs(self.windows) do
+    if vim.api.nvim_win_is_valid(win) then
+      local col_offset = (i - 1) * (layout.col_width + layout.gap)
+      vim.api.nvim_win_set_config(win, {
+        relative = "editor",
+        row = layout.start_row,
+        col = layout.start_col + col_offset,
+        width = layout.col_width,
+        height = layout.board_height,
+      })
+    end
+  end
+end
+
+--- Close the board and clean up all windows and buffers.
+function Board:close()
+  if self.augroup then
+    vim.api.nvim_del_augroup_by_id(self.augroup)
+    self.augroup = nil
+  end
+
+  for _, win in ipairs(self.windows) do
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_close(win, true)
+    end
+  end
+
+  -- Buffers with bufhidden=wipe are cleaned up automatically
+  self.windows = {}
+  self.buffers = {}
+  self.columns = nil
+  self.data = nil
+  instance = nil
+end
+
+--- Refresh the board with new data.
+---@param data table Board data from api.fetch_all_columns
+function Board:refresh(data)
+  self:close()
+  self:open(data)
+end
+
+--- Check if the board is currently open.
+---@return boolean
+function Board:is_open()
+  return #self.windows > 0
+end
+
+-- ---------------------------------------------------------------------------
+-- Singleton access
+-- ---------------------------------------------------------------------------
+
+--- Get or create the singleton board instance.
+---@return table
+function Board.get_instance()
+  if not instance then
+    instance = Board.new()
+  end
+  return instance
+end
+
+--- Close the singleton instance if it exists.
+function Board.close_instance()
+  if instance then
+    instance:close()
+  end
+end
+
+return Board

--- a/lua/okuban/ui/card.lua
+++ b/lua/okuban/ui/card.lua
@@ -1,0 +1,32 @@
+local M = {}
+
+--- Format a single issue as a card line.
+---@param issue table { number, title, assignees }
+---@param width integer Available width for text
+---@return string
+function M.render_card(issue, width)
+  local prefix = "#" .. issue.number .. " "
+  local available = width - #prefix
+  local title = issue.title or ""
+  if #title > available then
+    title = title:sub(1, available - 3) .. "..."
+  end
+  return prefix .. title
+end
+
+--- Render all cards for a column.
+---@param issues table[] List of issues
+---@param width integer Available width for text
+---@return string[] lines
+function M.render_column(issues, width)
+  if #issues == 0 then
+    return { "  (no issues)" }
+  end
+  local lines = {}
+  for _, issue in ipairs(issues) do
+    table.insert(lines, M.render_card(issue, width))
+  end
+  return lines
+end
+
+return M

--- a/tests/test_board_layout_spec.lua
+++ b/tests/test_board_layout_spec.lua
@@ -1,0 +1,57 @@
+describe("okuban.ui.board layout", function()
+  local Board
+
+  before_each(function()
+    package.loaded["okuban.ui.board"] = nil
+    package.loaded["okuban.config"] = nil
+    require("okuban.config")
+    Board = require("okuban.ui.board")
+  end)
+
+  describe("calculate_layout", function()
+    it("calculates correct dimensions for 5 columns on 120x40 terminal", function()
+      local layout = Board.calculate_layout(5, 120, 40)
+      assert.equals(108, layout.board_width) -- floor(120 * 0.9)
+      assert.equals(32, layout.board_height) -- floor(40 * 0.8)
+      -- col_width = floor((108 - 4*1) / 5) = floor(104/5) = 20
+      assert.equals(20, layout.col_width)
+      assert.equals(1, layout.gap)
+    end)
+
+    it("calculates correct dimensions for 6 columns on 160x50 terminal", function()
+      local layout = Board.calculate_layout(6, 160, 50)
+      assert.equals(144, layout.board_width) -- floor(160 * 0.9)
+      assert.equals(40, layout.board_height) -- floor(50 * 0.8)
+      -- col_width = floor((144 - 5*1) / 6) = floor(139/6) = 23
+      assert.equals(23, layout.col_width)
+    end)
+
+    it("enforces minimum column width of 20", function()
+      -- Very narrow terminal: 5 columns on 60 wide
+      local layout = Board.calculate_layout(5, 60, 40)
+      assert.equals(20, layout.col_width) -- min width enforced
+    end)
+
+    it("centers the board on screen", function()
+      local layout = Board.calculate_layout(5, 120, 40)
+      -- start_col = floor((120 - 108) / 2) = 6
+      assert.equals(6, layout.start_col)
+      -- start_row = floor((40 - 32) / 2) = 4
+      assert.equals(4, layout.start_row)
+    end)
+
+    it("works with single column", function()
+      local layout = Board.calculate_layout(1, 120, 40)
+      assert.equals(108, layout.board_width)
+      -- col_width = floor((108 - 0) / 1) = 108
+      assert.equals(108, layout.col_width)
+    end)
+
+    it("handles very small terminal gracefully", function()
+      local layout = Board.calculate_layout(5, 30, 10)
+      -- Min col_width = 20, board adjusted
+      assert.equals(20, layout.col_width)
+      assert.is_true(layout.board_height > 0)
+    end)
+  end)
+end)

--- a/tests/test_card_render_spec.lua
+++ b/tests/test_card_render_spec.lua
@@ -1,0 +1,62 @@
+describe("okuban.ui.card", function()
+  local card_mod
+
+  before_each(function()
+    package.loaded["okuban.ui.card"] = nil
+    card_mod = require("okuban.ui.card")
+  end)
+
+  describe("render_card", function()
+    it("formats issue as #number title", function()
+      local line = card_mod.render_card({ number = 42, title = "Add board rendering" }, 40)
+      assert.equals("#42 Add board rendering", line)
+    end)
+
+    it("truncates long titles with ellipsis", function()
+      local line = card_mod.render_card({ number = 1, title = "This is a very long title that exceeds" }, 20)
+      -- prefix "#1 " = 3 chars, available = 17, title truncated to 14 + "..." = 17
+      assert.equals("#1 This is a very...", line)
+      assert.is_true(#line <= 20)
+    end)
+
+    it("handles single-digit issue numbers", function()
+      local line = card_mod.render_card({ number = 5, title = "Short" }, 30)
+      assert.equals("#5 Short", line)
+    end)
+
+    it("handles large issue numbers", function()
+      local line = card_mod.render_card({ number = 12345, title = "Big number" }, 40)
+      assert.equals("#12345 Big number", line)
+    end)
+
+    it("handles missing title", function()
+      local line = card_mod.render_card({ number = 1 }, 20)
+      assert.equals("#1 ", line)
+    end)
+
+    it("handles exact-fit title", function()
+      local line = card_mod.render_card({ number = 1, title = "12345678901234567" }, 20)
+      -- prefix "#1 " = 3 chars, available = 17, title fits exactly
+      assert.equals("#1 12345678901234567", line)
+    end)
+  end)
+
+  describe("render_column", function()
+    it("renders all cards", function()
+      local issues = {
+        { number = 1, title = "First" },
+        { number = 2, title = "Second" },
+      }
+      local lines = card_mod.render_column(issues, 30)
+      assert.equals(2, #lines)
+      assert.equals("#1 First", lines[1])
+      assert.equals("#2 Second", lines[2])
+    end)
+
+    it("shows placeholder for empty column", function()
+      local lines = card_mod.render_column({}, 30)
+      assert.equals(1, #lines)
+      assert.equals("  (no issues)", lines[1])
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Board singleton with side-by-side floating windows (one per column)
- Window titles show column name + count: ` Todo (3) `
- Card rendering: `#42 Issue title` with smart truncation
- Empty columns show `(no issues)` placeholder
- `VimResized` repositions windows, `WinClosed` triggers full cleanup
- Toggle behavior: re-opening closes existing board
- 14 new tests for layout math and card formatting (50 total)

## Test plan
- [x] `make test` passes (50 tests)
- [x] `make lint` passes
- [x] Layout calculations correct for various terminal sizes
- [x] Card truncation handles edge cases
- [x] Minimum column width enforced

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)