### PR TITLE
feat(ui): semantic hjkl navigation between columns and cards

### DIFF
--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -130,6 +130,14 @@ function Board:open(data)
   -- Store column metadata for navigation
   self.columns = cols
 
+  -- Set up navigation
+  local Navigation = require("okuban.ui.navigation")
+  self.navigation = Navigation.new(self)
+  for _, buf in ipairs(self.buffers) do
+    self.navigation:setup_keymaps(buf)
+  end
+  self.navigation:highlight_current()
+
   -- VimResized handler
   vim.api.nvim_create_autocmd("VimResized", {
     group = self.augroup,
@@ -197,6 +205,7 @@ function Board:close()
   self.buffers = {}
   self.columns = nil
   self.data = nil
+  self.navigation = nil
   instance = nil
 end
 

--- a/lua/okuban/ui/navigation.lua
+++ b/lua/okuban/ui/navigation.lua
@@ -1,0 +1,178 @@
+local config = require("okuban.config")
+
+local Navigation = {}
+Navigation.__index = Navigation
+
+local ns_id = vim.api.nvim_create_namespace("okuban_card_focus")
+
+--- Create a new Navigation instance attached to a board.
+---@param board table Board instance
+---@return table
+function Navigation.new(board)
+  local o = setmetatable({}, Navigation)
+  o.board = board
+  o.column_index = 1
+  o.card_index = 1
+  return o
+end
+
+--- Get the number of cards in a column.
+---@param col_idx integer
+---@return integer
+function Navigation:card_count(col_idx)
+  local col = self.board.columns[col_idx]
+  if not col then
+    return 0
+  end
+  return #col.issues
+end
+
+--- Get the total number of columns.
+---@return integer
+function Navigation:num_columns()
+  return #self.board.columns
+end
+
+--- Move to the next column (right).
+function Navigation:move_right()
+  if self.column_index < self:num_columns() then
+    self.column_index = self.column_index + 1
+    -- Clamp card_index to new column's size
+    local count = self:card_count(self.column_index)
+    if count == 0 then
+      self.card_index = 1
+    elseif self.card_index > count then
+      self.card_index = count
+    end
+    self:_focus_window()
+    self:highlight_current()
+  end
+end
+
+--- Move to the previous column (left).
+function Navigation:move_left()
+  if self.column_index > 1 then
+    self.column_index = self.column_index - 1
+    local count = self:card_count(self.column_index)
+    if count == 0 then
+      self.card_index = 1
+    elseif self.card_index > count then
+      self.card_index = count
+    end
+    self:_focus_window()
+    self:highlight_current()
+  end
+end
+
+--- Move to the next card (down).
+function Navigation:move_down()
+  local count = self:card_count(self.column_index)
+  if self.card_index < count then
+    self.card_index = self.card_index + 1
+    self:highlight_current()
+  end
+end
+
+--- Move to the previous card (up).
+function Navigation:move_up()
+  if self.card_index > 1 then
+    self.card_index = self.card_index - 1
+    self:highlight_current()
+  end
+end
+
+--- Focus the window corresponding to the current column.
+function Navigation:_focus_window()
+  local win = self.board.windows[self.column_index]
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_set_current_win(win)
+  end
+end
+
+--- Highlight the currently focused card using extmarks.
+function Navigation:highlight_current()
+  -- Clear all highlights in all board buffers
+  for _, buf in ipairs(self.board.buffers) do
+    if vim.api.nvim_buf_is_valid(buf) then
+      vim.api.nvim_buf_clear_namespace(buf, ns_id, 0, -1)
+    end
+  end
+
+  -- Add highlight to the current card
+  local buf = self.board.buffers[self.column_index]
+  if not buf or not vim.api.nvim_buf_is_valid(buf) then
+    return
+  end
+
+  local line = self.card_index - 1 -- 0-indexed
+  local line_count = vim.api.nvim_buf_line_count(buf)
+  if line >= 0 and line < line_count then
+    vim.api.nvim_buf_add_highlight(buf, ns_id, "OkubanCardFocused", line, 0, -1)
+  end
+
+  -- Set cursor position in the window
+  local win = self.board.windows[self.column_index]
+  if win and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_set_cursor(win, { self.card_index, 0 })
+  end
+end
+
+--- Get the issue data for the currently selected card.
+---@return table|nil issue
+function Navigation:get_selected_issue()
+  local col = self.board.columns[self.column_index]
+  if not col then
+    return nil
+  end
+  return col.issues[self.card_index]
+end
+
+--- Get the label of the currently selected column.
+---@return string|nil
+function Navigation:get_selected_column_label()
+  local col = self.board.columns[self.column_index]
+  if not col then
+    return nil
+  end
+  -- data.columns have label field, unsorted column does not
+  local board_col = self.board.data and self.board.data.columns[self.column_index]
+  return board_col and board_col.label or nil
+end
+
+--- Set up keymaps on a board buffer.
+---@param buf integer Buffer handle
+function Navigation:setup_keymaps(buf)
+  local keymaps = config.get().keymaps
+  local opts = { buffer = buf, nowait = true, silent = true }
+
+  vim.keymap.set("n", keymaps.column_left, function()
+    self:move_left()
+  end, opts)
+
+  vim.keymap.set("n", keymaps.column_right, function()
+    self:move_right()
+  end, opts)
+
+  vim.keymap.set("n", keymaps.card_up, function()
+    self:move_up()
+  end, opts)
+
+  vim.keymap.set("n", keymaps.card_down, function()
+    self:move_down()
+  end, opts)
+
+  vim.keymap.set("n", keymaps.close, function()
+    self.board:close()
+  end, opts)
+
+  vim.keymap.set("n", keymaps.refresh, function()
+    local api = require("okuban.api")
+    api.fetch_all_columns(function(data)
+      if data then
+        self.board:refresh(data)
+      end
+    end)
+  end, opts)
+end
+
+return Navigation

--- a/tests/test_navigation_spec.lua
+++ b/tests/test_navigation_spec.lua
@@ -1,0 +1,187 @@
+describe("okuban.ui.navigation", function()
+  local Navigation
+
+  before_each(function()
+    package.loaded["okuban.ui.navigation"] = nil
+    package.loaded["okuban.config"] = nil
+    require("okuban.config")
+    Navigation = require("okuban.ui.navigation")
+  end)
+
+  --- Create a mock board with the given column sizes.
+  ---@param sizes integer[] Number of issues per column
+  ---@return table mock_board
+  local function mock_board(sizes)
+    local columns = {}
+    local windows = {}
+    local buffers = {}
+    for i, count in ipairs(sizes) do
+      local issues = {}
+      for j = 1, count do
+        table.insert(issues, { number = i * 100 + j, title = "Issue " .. j })
+      end
+      table.insert(columns, { name = "Col" .. i, issues = issues })
+      table.insert(windows, i) -- fake window handles
+      table.insert(buffers, i) -- fake buffer handles
+    end
+    return {
+      columns = columns,
+      windows = windows,
+      buffers = buffers,
+      data = { columns = columns },
+    }
+  end
+
+  describe("initialization", function()
+    it("starts at column 1, card 1", function()
+      local board = mock_board({ 3, 2, 5 })
+      local nav = Navigation.new(board)
+      assert.equals(1, nav.column_index)
+      assert.equals(1, nav.card_index)
+    end)
+  end)
+
+  describe("move_right", function()
+    it("moves to the next column", function()
+      local board = mock_board({ 3, 2, 5 })
+      local nav = Navigation.new(board)
+      -- Stub _focus_window and highlight_current since we have no real windows
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+
+      nav:move_right()
+      assert.equals(2, nav.column_index)
+      assert.equals(1, nav.card_index)
+    end)
+
+    it("does not move past last column", function()
+      local board = mock_board({ 3, 2 })
+      local nav = Navigation.new(board)
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+
+      nav:move_right()
+      nav:move_right() -- should be clamped
+      assert.equals(2, nav.column_index)
+    end)
+
+    it("clamps card_index when new column has fewer cards", function()
+      local board = mock_board({ 5, 2 })
+      local nav = Navigation.new(board)
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+
+      nav.card_index = 5
+      nav:move_right()
+      assert.equals(2, nav.column_index)
+      assert.equals(2, nav.card_index) -- clamped from 5 to 2
+    end)
+  end)
+
+  describe("move_left", function()
+    it("moves to the previous column", function()
+      local board = mock_board({ 3, 2, 5 })
+      local nav = Navigation.new(board)
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+
+      nav.column_index = 3
+      nav:move_left()
+      assert.equals(2, nav.column_index)
+    end)
+
+    it("does not move before first column", function()
+      local board = mock_board({ 3, 2 })
+      local nav = Navigation.new(board)
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+
+      nav:move_left() -- already at 1
+      assert.equals(1, nav.column_index)
+    end)
+  end)
+
+  describe("move_down", function()
+    it("moves to the next card", function()
+      local board = mock_board({ 3, 2 })
+      local nav = Navigation.new(board)
+      nav.highlight_current = function() end
+
+      nav:move_down()
+      assert.equals(2, nav.card_index)
+    end)
+
+    it("does not move past last card", function()
+      local board = mock_board({ 3 })
+      local nav = Navigation.new(board)
+      nav.highlight_current = function() end
+
+      nav.card_index = 3
+      nav:move_down()
+      assert.equals(3, nav.card_index)
+    end)
+  end)
+
+  describe("move_up", function()
+    it("moves to the previous card", function()
+      local board = mock_board({ 3, 2 })
+      local nav = Navigation.new(board)
+      nav.highlight_current = function() end
+
+      nav.card_index = 3
+      nav:move_up()
+      assert.equals(2, nav.card_index)
+    end)
+
+    it("does not move before first card", function()
+      local board = mock_board({ 3 })
+      local nav = Navigation.new(board)
+      nav.highlight_current = function() end
+
+      nav:move_up()
+      assert.equals(1, nav.card_index)
+    end)
+  end)
+
+  describe("get_selected_issue", function()
+    it("returns the issue at current position", function()
+      local board = mock_board({ 3, 2 })
+      local nav = Navigation.new(board)
+      nav.card_index = 2
+
+      local issue = nav:get_selected_issue()
+      assert.is_not_nil(issue)
+      assert.equals(102, issue.number) -- col1 issue 2
+    end)
+
+    it("returns nil for invalid column", function()
+      local board = mock_board({ 3 })
+      local nav = Navigation.new(board)
+      nav.column_index = 99
+
+      assert.is_nil(nav:get_selected_issue())
+    end)
+  end)
+
+  describe("empty columns", function()
+    it("handles column with zero issues", function()
+      local board = mock_board({ 0, 3, 0 })
+      local nav = Navigation.new(board)
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+
+      assert.equals(0, nav:card_count(1))
+      assert.equals(3, nav:card_count(2))
+
+      -- Move right to column with issues
+      nav:move_right()
+      assert.equals(2, nav.column_index)
+      assert.equals(1, nav.card_index)
+
+      -- Move right to empty column
+      nav:move_right()
+      assert.equals(3, nav.column_index)
+      assert.equals(1, nav.card_index)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Navigation state model with `(column_index, card_index)` tracking
- `h`/`l` switch columns with card_index clamping
- `j`/`k` move between cards within a column, clamped at boundaries
- Extmark-based visual highlight on focused card
- All keymaps buffer-local, `nowait = true`, configurable via `config.keymaps`
- `q` closes board, `r` refreshes
- 13 new tests (63 total)

## Test plan
- [x] `make test` passes (63 tests)
- [x] `make lint` passes
- [x] Navigation state transitions correct
- [x] Card index clamped when moving to columns with fewer cards
- [x] Empty columns handled gracefully

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)