### PR TITLE
feat(ui): move cards between columns via label swap

### DIFF
--- a/lua/okuban/api.lua
+++ b/lua/okuban/api.lua
@@ -110,6 +110,32 @@ function M._gh_base_cmd()
   return gh_base_cmd()
 end
 
+--- Edit labels on an issue (remove one, add another).
+---@param number integer Issue number
+---@param remove_label string Label to remove
+---@param add_label string Label to add
+---@param callback fun(ok: boolean, err: string|nil)
+function M.edit_labels(number, remove_label, add_label, callback)
+  local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), {
+    "issue",
+    "edit",
+    tostring(number),
+    "--remove-label",
+    remove_label,
+    "--add-label",
+    add_label,
+  })
+  vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      if result.code == 0 then
+        callback(true, nil)
+      else
+        callback(false, result.stderr or "Failed to edit labels")
+      end
+    end)
+  end)
+end
+
 -- ---------------------------------------------------------------------------
 -- Fetch issues
 -- ---------------------------------------------------------------------------

--- a/lua/okuban/ui/move.lua
+++ b/lua/okuban/ui/move.lua
@@ -1,0 +1,93 @@
+local api = require("okuban.api")
+local config = require("okuban.config")
+local utils = require("okuban.utils")
+
+local M = {}
+
+--- Prompt the user to select a target column, then move the card.
+---@param board table Board instance
+function M.prompt_move(board)
+  local nav = board.navigation
+  if not nav then
+    return
+  end
+
+  local issue = nav:get_selected_issue()
+  if not issue then
+    utils.notify("No issue selected", vim.log.levels.WARN)
+    return
+  end
+
+  local current_label = nav:get_selected_column_label()
+  if not current_label then
+    utils.notify("Cannot move from this column", vim.log.levels.WARN)
+    return
+  end
+
+  -- Build list of target columns (excluding current)
+  local columns = config.get().columns
+  local targets = {}
+  for _, col in ipairs(columns) do
+    if col.label ~= current_label then
+      table.insert(targets, col)
+    end
+  end
+
+  if #targets == 0 then
+    utils.notify("No target columns available", vim.log.levels.WARN)
+    return
+  end
+
+  -- Build display names
+  local names = {}
+  for _, col in ipairs(targets) do
+    table.insert(names, col.name)
+  end
+
+  vim.ui.select(names, { prompt = "Move #" .. issue.number .. " to:" }, function(choice)
+    if not choice then
+      return
+    end
+
+    -- Find the selected target column
+    local target = nil
+    for _, col in ipairs(targets) do
+      if col.name == choice then
+        target = col
+        break
+      end
+    end
+
+    if not target then
+      return
+    end
+
+    M.execute_move(issue.number, current_label, target.label, target.name, board)
+  end)
+end
+
+--- Execute the label swap and refresh the board.
+---@param number integer Issue number
+---@param from_label string Current label
+---@param to_label string Target label
+---@param to_name string Target column display name
+---@param board table Board instance
+function M.execute_move(number, from_label, to_label, to_name, board)
+  api.edit_labels(number, from_label, to_label, function(ok, err)
+    if not ok then
+      utils.notify("Failed to move #" .. number .. ": " .. (err or "unknown error"), vim.log.levels.ERROR)
+      return
+    end
+
+    utils.notify("Moved #" .. number .. " to " .. to_name)
+
+    -- Refresh the board
+    api.fetch_all_columns(function(data)
+      if data then
+        board:refresh(data)
+      end
+    end)
+  end)
+end
+
+return M

--- a/lua/okuban/ui/navigation.lua
+++ b/lua/okuban/ui/navigation.lua
@@ -173,6 +173,11 @@ function Navigation:setup_keymaps(buf)
       end
     end)
   end, opts)
+
+  vim.keymap.set("n", keymaps.move_card, function()
+    local move = require("okuban.ui.move")
+    move.prompt_move(self.board)
+  end, opts)
 end
 
 return Navigation

--- a/tests/test_move_spec.lua
+++ b/tests/test_move_spec.lua
@@ -1,0 +1,148 @@
+local helpers = require("tests.helpers")
+
+describe("okuban.ui.move", function()
+  local move_mod
+
+  before_each(function()
+    package.loaded["okuban.ui.move"] = nil
+    package.loaded["okuban.config"] = nil
+    package.loaded["okuban.api"] = nil
+    require("okuban.config")
+    move_mod = require("okuban.ui.move")
+  end)
+
+  after_each(function()
+    helpers.restore_vim_system()
+  end)
+
+  describe("execute_move", function()
+    it("calls gh issue edit with correct label swap", function()
+      local calls = helpers.mock_vim_system({
+        { code = 0 }, -- edit_labels call
+        -- fetch_all_columns will fire 6 calls (5 columns + unsorted)
+        { code = 0, stdout = "[]" },
+        { code = 0, stdout = "[]" },
+        { code = 0, stdout = "[]" },
+        { code = 0, stdout = "[]" },
+        { code = 0, stdout = "[]" },
+        { code = 0, stdout = "[]" },
+      })
+
+      local refreshed = false
+      local mock_board = {
+        refresh = function()
+          refreshed = true
+        end,
+      }
+
+      move_mod.execute_move(42, "okuban:todo", "okuban:in-progress", "In Progress", mock_board)
+
+      vim.wait(2000, function()
+        return #calls >= 1
+      end)
+
+      -- Verify the first call is the label edit
+      local cmd = calls[1].cmd
+      assert.truthy(vim.tbl_contains(cmd, "issue"))
+      assert.truthy(vim.tbl_contains(cmd, "edit"))
+      assert.truthy(vim.tbl_contains(cmd, "42"))
+      assert.truthy(vim.tbl_contains(cmd, "--remove-label"))
+      assert.truthy(vim.tbl_contains(cmd, "okuban:todo"))
+      assert.truthy(vim.tbl_contains(cmd, "--add-label"))
+      assert.truthy(vim.tbl_contains(cmd, "okuban:in-progress"))
+
+      -- Wait for refresh to trigger
+      vim.wait(2000, function()
+        return refreshed
+      end)
+    end)
+
+    it("shows error notification on failure", function()
+      helpers.mock_vim_system({
+        { code = 1, stderr = "permission denied" },
+      })
+
+      local mock_board = {
+        refresh = function() end,
+      }
+
+      local done = false
+      -- Capture notification
+      local notified_msg = nil
+      local orig_notify = vim.notify
+      vim.notify = function(msg)
+        notified_msg = msg
+        done = true
+      end
+
+      move_mod.execute_move(42, "okuban:todo", "okuban:in-progress", "In Progress", mock_board)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      vim.notify = orig_notify
+      assert.truthy(notified_msg)
+      assert.truthy(notified_msg:match("Failed"))
+    end)
+  end)
+
+  describe("prompt_move", function()
+    it("builds target list excluding current column", function()
+      -- We test the internal logic by checking that vim.ui.select receives
+      -- the right number of options
+      local select_items = nil
+      local orig_select = vim.ui.select
+      vim.ui.select = function(items)
+        select_items = items
+      end
+
+      local nav = {
+        get_selected_issue = function()
+          return { number = 42, title = "Test" }
+        end,
+        get_selected_column_label = function()
+          return "okuban:todo"
+        end,
+      }
+
+      local mock_board = {
+        navigation = nav,
+      }
+
+      move_mod.prompt_move(mock_board)
+
+      vim.ui.select = orig_select
+
+      -- Should have 4 targets (5 columns minus current)
+      assert.is_not_nil(select_items)
+      assert.equals(4, #select_items)
+      -- "Todo" should not be in the list
+      for _, name in ipairs(select_items) do
+        assert.is_not.equals("Todo", name)
+      end
+    end)
+
+    it("does nothing when no issue is selected", function()
+      local select_called = false
+      local orig_select = vim.ui.select
+      vim.ui.select = function()
+        select_called = true
+      end
+
+      local nav = {
+        get_selected_issue = function()
+          return nil
+        end,
+        get_selected_column_label = function()
+          return "okuban:todo"
+        end,
+      }
+
+      move_mod.prompt_move({ navigation = nav })
+
+      vim.ui.select = orig_select
+      assert.is_false(select_called)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Press `m` on a card → `vim.ui.select` picker (excludes current column)
- Selection triggers `gh issue edit --remove-label <old> --add-label <new>`
- Board auto-refreshes after successful move
- Success/error notifications
- `api.edit_labels()` for reusable label swap API
- 4 new tests (67 total)

## Test plan
- [x] `make test` passes (67 tests)
- [x] `make lint` passes
- [x] Correct gh command construction verified
- [x] Target list excludes current column
- [x] Error cases handled with notifications

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)