### PR TITLE
test(e2e): integration tests, help float, and Phase 1 polish

### DIFF
--- a/doc/okuban.txt
+++ b/doc/okuban.txt
@@ -1,0 +1,111 @@
+*okuban.txt*        GitHub Issues Kanban Board for Neovim
+
+Author:   khwerhahn
+License:  MIT
+Homepage: https://github.com/khwerhahn/okuban.nvim
+
+==============================================================================
+CONTENTS                                                     *okuban-contents*
+
+  1. Introduction ...................... |okuban-introduction|
+  2. Requirements ...................... |okuban-requirements|
+  3. Setup ............................. |okuban-setup|
+  4. Commands .......................... |okuban-commands|
+  5. Keybindings ....................... |okuban-keybindings|
+  6. Configuration ..................... |okuban-configuration|
+
+==============================================================================
+1. INTRODUCTION                                          *okuban-introduction*
+
+okuban.nvim turns GitHub issues into an interactive kanban board inside
+Neovim. Issues are sorted into columns based on labels with the `okuban:`
+prefix. No GitHub Projects setup required.
+
+==============================================================================
+2. REQUIREMENTS                                          *okuban-requirements*
+
+- Neovim 0.10+
+- `gh` CLI (https://cli.github.com) — installed and authenticated
+- `repo` scope (default in `gh auth login`)
+
+==============================================================================
+3. SETUP                                                       *okuban-setup*
+
+Using lazy.nvim: >lua
+  {
+    "khwerhahn/okuban.nvim",
+    cmd = { "Okuban", "OkubanSetup", "OkubanRefresh", "OkubanClose" },
+    opts = {},
+  }
+<
+
+Then run `:OkubanSetup` to create the kanban labels on your repo.
+
+==============================================================================
+4. COMMANDS                                                 *okuban-commands*
+
+:Okuban                                                            *:Okuban*
+  Open the kanban board for the current repository.
+
+:OkubanClose                                                  *:OkubanClose*
+  Close the kanban board.
+
+:OkubanRefresh                                              *:OkubanRefresh*
+  Refresh the kanban board with latest data from GitHub.
+
+:OkubanSetup [--full]                                        *:OkubanSetup*
+  Create kanban labels on the current repository.
+  Without arguments: creates 5 column labels (okuban:backlog, okuban:todo,
+  okuban:in-progress, okuban:review, okuban:done).
+  With `--full`: also creates type, priority, and community labels (~17 total).
+
+==============================================================================
+5. KEYBINDINGS                                           *okuban-keybindings*
+
+All keybindings are buffer-local to the board windows and configurable
+via the `keymaps` option in |okuban-configuration|.
+
+  Key   Action ~
+  h     Move to previous column
+  l     Move to next column
+  k     Move to previous card
+  j     Move to next card
+  m     Move card to another column
+  r     Refresh board
+  ?     Toggle help
+  q     Close board
+
+==============================================================================
+6. CONFIGURATION                                       *okuban-configuration*
+
+Pass options to `setup()`: >lua
+  require("okuban").setup({
+    columns = {
+      { label = "okuban:backlog",     name = "Backlog",     color = "#c5def5" },
+      { label = "okuban:todo",        name = "Todo",        color = "#0075ca" },
+      { label = "okuban:in-progress", name = "In Progress", color = "#fbca04" },
+      { label = "okuban:review",      name = "Review",      color = "#d4c5f9" },
+      { label = "okuban:done",        name = "Done",        color = "#0e8a16" },
+    },
+    show_unsorted = true,
+    skip_preflight = false,
+    github_hostname = nil,
+    keymaps = {
+      column_left  = "h",
+      column_right = "l",
+      card_up      = "k",
+      card_down    = "j",
+      move_card    = "m",
+      close        = "q",
+      refresh      = "r",
+      help         = "?",
+    },
+    claude = {
+      enabled = true,
+      max_budget_usd = 5.00,
+      max_turns = 30,
+    },
+  })
+<
+
+ vim:tw=78:ft=help:norl:

--- a/lua/okuban/ui/help.lua
+++ b/lua/okuban/ui/help.lua
@@ -1,0 +1,73 @@
+local config = require("okuban.config")
+
+local M = {}
+
+local help_win = nil
+local help_buf = nil
+
+--- Open a floating help window showing all keybindings.
+function M.open()
+  if help_win and vim.api.nvim_win_is_valid(help_win) then
+    M.close()
+    return
+  end
+
+  local keymaps = config.get().keymaps
+  local lines = {
+    "  Okuban Keybindings",
+    "  ──────────────────",
+    "",
+    "  " .. keymaps.column_left .. "      Previous column",
+    "  " .. keymaps.column_right .. "      Next column",
+    "  " .. keymaps.card_up .. "      Previous card",
+    "  " .. keymaps.card_down .. "      Next card",
+    "  " .. keymaps.move_card .. "      Move card to column",
+    "  " .. keymaps.refresh .. "      Refresh board",
+    "  " .. keymaps.help .. "      Toggle this help",
+    "  " .. keymaps.close .. "      Close board",
+  }
+
+  local width = 30
+  local height = #lines
+
+  help_buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(help_buf, 0, -1, false, lines)
+  vim.bo[help_buf].buftype = "nofile"
+  vim.bo[help_buf].bufhidden = "wipe"
+  vim.bo[help_buf].modifiable = false
+
+  local screen_w = vim.o.columns
+  local screen_h = vim.o.lines
+
+  help_win = vim.api.nvim_open_win(help_buf, true, {
+    relative = "editor",
+    row = math.floor((screen_h - height) / 2),
+    col = math.floor((screen_w - width) / 2),
+    width = width,
+    height = height,
+    style = "minimal",
+    border = "rounded",
+    title = " Help ",
+    title_pos = "center",
+    zindex = 60,
+  })
+
+  -- Close on q or Esc or ?
+  local close_keys = { "q", "<Esc>", keymaps.help }
+  for _, key in ipairs(close_keys) do
+    vim.keymap.set("n", key, function()
+      M.close()
+    end, { buffer = help_buf, nowait = true, silent = true })
+  end
+end
+
+--- Close the help window.
+function M.close()
+  if help_win and vim.api.nvim_win_is_valid(help_win) then
+    vim.api.nvim_win_close(help_win, true)
+  end
+  help_win = nil
+  help_buf = nil
+end
+
+return M

--- a/lua/okuban/ui/navigation.lua
+++ b/lua/okuban/ui/navigation.lua
@@ -178,6 +178,11 @@ function Navigation:setup_keymaps(buf)
     local move = require("okuban.ui.move")
     move.prompt_move(self.board)
   end, opts)
+
+  vim.keymap.set("n", keymaps.help, function()
+    local help = require("okuban.ui.help")
+    help.open()
+  end, opts)
 end
 
 return Navigation

--- a/tests/test_integration_spec.lua
+++ b/tests/test_integration_spec.lua
@@ -1,0 +1,197 @@
+local helpers = require("tests.helpers")
+
+describe("okuban integration", function()
+  local api, config, Navigation
+
+  before_each(function()
+    -- Reset all modules
+    for key, _ in pairs(package.loaded) do
+      if key:match("^okuban") then
+        package.loaded[key] = nil
+      end
+    end
+    config = require("okuban.config")
+    api = require("okuban.api")
+    Navigation = require("okuban.ui.navigation")
+    api._reset_preflight()
+  end)
+
+  after_each(function()
+    helpers.restore_vim_system()
+  end)
+
+  describe("full flow with mock data", function()
+    it("navigation state transitions work end-to-end", function()
+      -- Simulate a board with 3 columns of varying sizes
+      local columns = {
+        {
+          name = "Todo",
+          issues = {
+            { number = 1, title = "First task" },
+            { number = 2, title = "Second task" },
+            { number = 3, title = "Third task" },
+          },
+        },
+        { name = "In Progress", issues = {
+          { number = 4, title = "Active work" },
+        } },
+        {
+          name = "Done",
+          issues = {
+            { number = 5, title = "Completed" },
+            { number = 6, title = "Also done" },
+          },
+        },
+      }
+
+      local mock_board = {
+        columns = columns,
+        windows = { 1, 2, 3 },
+        buffers = { 1, 2, 3 },
+        data = { columns = columns },
+      }
+
+      local nav = Navigation.new(mock_board)
+      -- Stub UI methods since we have no real windows
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+
+      -- Start at column 1, card 1
+      assert.equals(1, nav.column_index)
+      assert.equals(1, nav.card_index)
+      assert.equals(1, nav:get_selected_issue().number)
+
+      -- Move down through todo column
+      nav:move_down()
+      assert.equals(2, nav.card_index)
+      assert.equals(2, nav:get_selected_issue().number)
+
+      nav:move_down()
+      assert.equals(3, nav.card_index)
+
+      -- Move right to "In Progress" - card_index should clamp to 1
+      nav:move_right()
+      assert.equals(2, nav.column_index)
+      assert.equals(1, nav.card_index)
+      assert.equals(4, nav:get_selected_issue().number)
+
+      -- Move right to "Done"
+      nav:move_right()
+      assert.equals(3, nav.column_index)
+      assert.equals(1, nav.card_index)
+
+      -- Move down in "Done"
+      nav:move_down()
+      assert.equals(2, nav.card_index)
+      assert.equals(6, nav:get_selected_issue().number)
+
+      -- Move left back to "In Progress" - should clamp to 1
+      nav:move_left()
+      assert.equals(2, nav.column_index)
+      assert.equals(1, nav.card_index)
+
+      -- Boundary: can't move right past last column
+      nav.column_index = 3
+      nav:move_right()
+      assert.equals(3, nav.column_index)
+
+      -- Boundary: can't move left past first column
+      nav.column_index = 1
+      nav:move_left()
+      assert.equals(1, nav.column_index)
+    end)
+  end)
+
+  describe("api preflight + fetch pipeline", function()
+    it("preflight failure prevents fetch", function()
+      helpers.mock_vim_system({
+        { code = 1, stderr = "not logged in" }, -- auth fails
+      })
+
+      local preflight_ok = nil
+      api.preflight(function(ok)
+        preflight_ok = ok
+      end)
+
+      vim.wait(1000, function()
+        return preflight_ok ~= nil
+      end)
+
+      assert.is_false(preflight_ok)
+    end)
+
+    it("successful preflight allows fetch", function()
+      local calls = helpers.mock_vim_system({
+        { code = 0, stdout = "Logged in" }, -- auth
+        { code = 0, stdout = "okuban.nvim\n" }, -- repo
+        -- fetch: 5 columns + unsorted = 6 calls
+        { code = 0, stdout = "[]" },
+        { code = 0, stdout = "[]" },
+        { code = 0, stdout = "[]" },
+        { code = 0, stdout = "[]" },
+        { code = 0, stdout = "[]" },
+        { code = 0, stdout = "[]" },
+      })
+
+      local fetch_result = nil
+      api.preflight(function(ok)
+        assert.is_true(ok)
+        api.fetch_all_columns(function(data)
+          fetch_result = data
+        end)
+      end)
+
+      vim.wait(3000, function()
+        return fetch_result ~= nil
+      end)
+
+      assert.is_not_nil(fetch_result)
+      assert.equals(5, #fetch_result.columns)
+      assert.equals(8, #calls) -- 2 preflight + 6 fetch
+    end)
+  end)
+
+  describe("edit_labels", function()
+    it("constructs correct gh command for label swap", function()
+      local calls = helpers.mock_vim_system({
+        { code = 0 },
+      })
+
+      local done = false
+      api.edit_labels(42, "okuban:todo", "okuban:in-progress", function(ok)
+        done = true
+        assert.is_true(ok)
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+
+      local cmd = calls[1].cmd
+      assert.truthy(vim.tbl_contains(cmd, "issue"))
+      assert.truthy(vim.tbl_contains(cmd, "edit"))
+      assert.truthy(vim.tbl_contains(cmd, "42"))
+      assert.truthy(vim.tbl_contains(cmd, "--remove-label"))
+      assert.truthy(vim.tbl_contains(cmd, "okuban:todo"))
+      assert.truthy(vim.tbl_contains(cmd, "--add-label"))
+      assert.truthy(vim.tbl_contains(cmd, "okuban:in-progress"))
+    end)
+  end)
+
+  describe("config integration", function()
+    it("all modules respect config overrides", function()
+      config.setup({
+        columns = {
+          { label = "custom:a", name = "Alpha", color = "#111111" },
+          { label = "custom:b", name = "Beta", color = "#222222" },
+        },
+        keymaps = { close = "<Esc>" },
+      })
+
+      local cfg = config.get()
+      assert.equals(2, #cfg.columns)
+      assert.equals("custom:a", cfg.columns[1].label)
+      assert.equals("<Esc>", cfg.keymaps.close)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Help overlay (`?` key): floating window showing all keybindings, reads from config
- Vimdoc (`doc/okuban.txt`): full `:help okuban` with commands, keybindings, config
- Integration tests: full navigation flow, preflight→fetch pipeline, label swap, config overrides
- 5 new tests (72 total across 8 test files)

## Test plan
- [x] `make test` passes (72 tests)
- [x] `make lint` passes (StyLua + Luacheck)
- [x] `:help okuban` renders vimdoc
- [x] `?` opens help float, `q`/`<Esc>` closes it
- [x] Full navigation flow verified end-to-end

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)