### PR TITLE
fix(api): use per-column state filter so Done column shows closed issues

### DIFF
--- a/lua/okuban/api.lua
+++ b/lua/okuban/api.lua
@@ -144,8 +144,9 @@ local ISSUE_FIELDS = "number,title,assignees,labels,state"
 
 --- Fetch issues for a single label.
 ---@param label string The label to filter by
+---@param state string|nil Issue state filter: "open", "closed", or "all" (default: "open")
 ---@param callback fun(issues: table[]|nil, err: string|nil)
-function M.fetch_column(label, callback)
+function M.fetch_column(label, state, callback)
   local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), {
     "issue",
     "list",
@@ -156,7 +157,7 @@ function M.fetch_column(label, callback)
     "--limit",
     "100",
     "--state",
-    "open",
+    state or "open",
   })
   vim.system(cmd, { text = true }, function(result)
     vim.schedule(function()
@@ -259,7 +260,7 @@ function M.fetch_all_columns(callback)
 
   -- Fire all column fetches in parallel
   for _, col in ipairs(columns) do
-    M.fetch_column(col.label, function(issues, err)
+    M.fetch_column(col.label, col.state, function(issues, err)
       if err then
         utils.notify(err, vim.log.levels.WARN)
       end

--- a/lua/okuban/config.lua
+++ b/lua/okuban/config.lua
@@ -4,6 +4,7 @@ local M = {}
 ---@field label string
 ---@field name string
 ---@field color string
+---@field state string|nil "open", "closed", or "all" (default: "open")
 
 ---@class OkubanKeymaps
 ---@field column_left string
@@ -35,7 +36,7 @@ local defaults = {
     { label = "okuban:todo", name = "Todo", color = "#0075ca" },
     { label = "okuban:in-progress", name = "In Progress", color = "#fbca04" },
     { label = "okuban:review", name = "Review", color = "#d4c5f9" },
-    { label = "okuban:done", name = "Done", color = "#0e8a16" },
+    { label = "okuban:done", name = "Done", color = "#0e8a16", state = "all" },
   },
   show_unsorted = true,
   skip_preflight = false,

--- a/tests/test_api_fetch_spec.lua
+++ b/tests/test_api_fetch_spec.lua
@@ -32,7 +32,7 @@ describe("okuban.api fetch", function()
 
       local done = false
       local result = nil
-      api.fetch_column("okuban:todo", function(issues)
+      api.fetch_column("okuban:todo", nil, function(issues)
         done = true
         result = issues
       end)
@@ -53,7 +53,7 @@ describe("okuban.api fetch", function()
 
       local done = false
       local result = nil
-      api.fetch_column("okuban:todo", function(issues)
+      api.fetch_column("okuban:todo", nil, function(issues)
         done = true
         result = issues
       end)
@@ -72,7 +72,7 @@ describe("okuban.api fetch", function()
       local done = false
       local result_issues = "not_nil"
       local result_err = nil
-      api.fetch_column("okuban:todo", function(issues, err)
+      api.fetch_column("okuban:todo", nil, function(issues, err)
         done = true
         result_issues = issues
         result_err = err
@@ -91,7 +91,7 @@ describe("okuban.api fetch", function()
       })
 
       local done = false
-      api.fetch_column("okuban:in-progress", function()
+      api.fetch_column("okuban:in-progress", nil, function()
         done = true
       end)
 
@@ -107,6 +107,27 @@ describe("okuban.api fetch", function()
       assert.truthy(vim.tbl_contains(cmd, "--json"))
       assert.truthy(vim.tbl_contains(cmd, "--limit"))
       assert.truthy(vim.tbl_contains(cmd, "100"))
+      assert.truthy(vim.tbl_contains(cmd, "--state"))
+      assert.truthy(vim.tbl_contains(cmd, "open"))
+    end)
+
+    it("passes state parameter to gh command", function()
+      local calls = helpers.mock_vim_system({
+        { code = 0, stdout = "[]" },
+      })
+
+      local done = false
+      api.fetch_column("okuban:done", "all", function()
+        done = true
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+
+      local cmd = calls[1].cmd
+      assert.truthy(vim.tbl_contains(cmd, "--state"))
+      assert.truthy(vim.tbl_contains(cmd, "all"))
     end)
   end)
 
@@ -154,6 +175,46 @@ describe("okuban.api fetch", function()
       assert.is_not_nil(result.unsorted)
       assert.equals(1, #result.unsorted)
       assert.equals(99, result.unsorted[1].number)
+    end)
+
+    it("passes column state to fetch_column for Done column", function()
+      local responses = {}
+      for i = 1, 6 do
+        responses[i] = { code = 0, stdout = "[]" }
+      end
+      local calls = helpers.mock_vim_system(responses)
+
+      local done = false
+      api.fetch_all_columns(function()
+        done = true
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      -- The 5th column (Done) should use --state all
+      local done_cmd = calls[5].cmd
+      -- Find the index of "--state" and check the value after it
+      local state_val = nil
+      for i, v in ipairs(done_cmd) do
+        if v == "--state" then
+          state_val = done_cmd[i + 1]
+          break
+        end
+      end
+      assert.equals("all", state_val)
+
+      -- Other columns should use --state open (default)
+      local todo_cmd = calls[2].cmd
+      local todo_state = nil
+      for i, v in ipairs(todo_cmd) do
+        if v == "--state" then
+          todo_state = todo_cmd[i + 1]
+          break
+        end
+      end
+      assert.equals("open", todo_state)
     end)
 
     it("excludes unsorted when show_unsorted is false", function()


### PR DESCRIPTION
## Summary
- `fetch_column()` was hardcoding `--state open`, which filtered out closed issues from all columns
- Added `state` field to `OkubanColumn` config type — each column can now specify `"open"`, `"closed"`, or `"all"`
- Done column defaults to `state = "all"` so completed issues appear correctly
- `fetch_all_columns()` passes each column's `state` through to `fetch_column()`

## Test plan
- [x] New test: `fetch_column` passes state parameter to gh command (`--state all`)
- [x] New test: `fetch_all_columns` passes Done column's `state: "all"` correctly
- [x] Existing tests updated for new `fetch_column(label, state, callback)` signature
- [x] All 74 tests pass, lint clean

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)