### PR TITLE
feat(ui): worktree status indicators on cards

### DIFF
--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -1,6 +1,7 @@
 local card = require("okuban.ui.card")
 local config = require("okuban.config")
 local utils = require("okuban.utils")
+local worktree = require("okuban.worktree")
 
 local Board = {}
 Board.__index = Board
@@ -12,7 +13,10 @@ local instance = nil
 local function define_highlights()
   vim.api.nvim_set_hl(0, "OkubanCardFocused", { default = true, link = "CursorLine" })
   vim.api.nvim_set_hl(0, "OkubanColumnHeader", { default = true, link = "Title" })
+  vim.api.nvim_set_hl(0, "OkubanCardActive", { default = true, link = "WarningMsg" })
 end
+
+local ns_active = vim.api.nvim_create_namespace("okuban_worktree_active")
 
 --- Calculate layout dimensions for the board.
 ---@param num_cols integer
@@ -170,6 +174,38 @@ function Board:_create_preview_window(layout)
   end, { buffer = buf, nowait = true, silent = true })
 end
 
+--- Apply orange highlight to cards that have an active worktree.
+--- Uses a separate namespace so it persists alongside focus highlights.
+---@param wt_map table<integer, table>|nil Worktree map
+function Board:_apply_active_highlights(wt_map)
+  -- Clear previous active highlights on all buffers
+  for _, buf in ipairs(self.buffers) do
+    if vim.api.nvim_buf_is_valid(buf) then
+      vim.api.nvim_buf_clear_namespace(buf, ns_active, 0, -1)
+    end
+  end
+
+  if not wt_map or not self.columns then
+    return
+  end
+
+  for i, col in ipairs(self.columns) do
+    local buf = self.buffers[i]
+    if buf and vim.api.nvim_buf_is_valid(buf) then
+      for card_idx, issue in ipairs(col.issues) do
+        if wt_map[issue.number] and wt_map[issue.number].active then
+          local ranges = col.card_ranges
+          if ranges and ranges[card_idx] then
+            for line_nr = ranges[card_idx].start_line, ranges[card_idx].end_line do
+              vim.api.nvim_buf_add_highlight(buf, ns_active, "OkubanCardActive", line_nr - 1, 0, -1)
+            end
+          end
+        end
+      end
+    end
+  end
+end
+
 --- Update the preview pane with the given issue's details.
 ---@param issue table|nil
 function Board:update_preview(issue)
@@ -185,7 +221,7 @@ function Board:update_preview(issue)
   local num_cols = #self.windows
   local layout = Board.calculate_layout(num_cols, nil, nil, preview_lines)
   local inner_width = layout.board_width - 2
-  local lines = card.render_preview(issue, inner_width, layout.preview_height)
+  local lines = card.render_preview(issue, inner_width, layout.preview_height, self.worktree_map)
 
   vim.bo[self.preview_buf].modifiable = true
   vim.api.nvim_buf_set_lines(self.preview_buf, 0, -1, false, lines)
@@ -393,13 +429,17 @@ function Board:populate(data)
   local preview_lines = cfg.preview_lines or 0
   local layout = Board.calculate_layout(#cols, nil, nil, preview_lines)
 
+  -- Fetch worktree map (sync, ~4ms) for card badges
+  local wt_map = worktree.fetch_worktree_map()
+  self.worktree_map = wt_map
+
   for i, col in ipairs(cols) do
     local buf = self.buffers[i]
     local win = self.windows[i]
 
     if buf and vim.api.nvim_buf_is_valid(buf) then
       local inner_width = layout.col_width - 2
-      local lines, card_ranges = card.render_column(col.issues, inner_width)
+      local lines, card_ranges = card.render_column(col.issues, inner_width, wt_map)
       col.card_ranges = card_ranges
 
       vim.bo[buf].modifiable = true
@@ -423,6 +463,35 @@ function Board:populate(data)
   end
 
   self.columns = cols
+
+  -- Apply orange highlight to active worktree cards
+  self:_apply_active_highlights(wt_map)
+
+  -- Enrich worktree map with dirty/clean status asynchronously
+  worktree.fetch_enriched(function(enriched_map)
+    if not self:is_open() then
+      return
+    end
+    self.worktree_map = enriched_map
+    -- Re-render columns with dirty/clean badges
+    for i, col in ipairs(self.columns) do
+      local buf = self.buffers[i]
+      if buf and vim.api.nvim_buf_is_valid(buf) then
+        local inner_width = layout.col_width - 2
+        local lines, card_ranges = card.render_column(col.issues, inner_width, enriched_map)
+        col.card_ranges = card_ranges
+        vim.bo[buf].modifiable = true
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+        vim.bo[buf].modifiable = false
+      end
+    end
+    -- Re-apply active highlights after re-rendering
+    self:_apply_active_highlights(enriched_map)
+    -- Re-highlight current card and update preview
+    if self.navigation then
+      self.navigation:highlight_current()
+    end
+  end)
 
   -- Set up or update navigation, preserving position during refresh
   local Navigation = require("okuban.ui.navigation")
@@ -462,6 +531,10 @@ function Board:open(data)
   local layout = Board.calculate_layout(#cols, nil, nil, preview_lines)
   self.augroup = vim.api.nvim_create_augroup("OkubanBoard", { clear = true })
 
+  -- Fetch worktree map for card badges
+  local wt_map = worktree.fetch_worktree_map()
+  self.worktree_map = wt_map
+
   for i, col in ipairs(cols) do
     local buf = vim.api.nvim_create_buf(false, true)
     vim.bo[buf].buftype = "nofile"
@@ -470,7 +543,7 @@ function Board:open(data)
     vim.bo[buf].filetype = "okuban"
 
     local inner_width = layout.col_width - 2
-    local lines, card_ranges = card.render_column(col.issues, inner_width)
+    local lines, card_ranges = card.render_column(col.issues, inner_width, wt_map)
     col.card_ranges = card_ranges
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
     vim.bo[buf].modifiable = false
@@ -507,6 +580,9 @@ function Board:open(data)
 
   -- Create preview window
   self:_create_preview_window(layout)
+
+  -- Apply orange highlight to active worktree cards
+  self:_apply_active_highlights(wt_map)
 
   -- Set up navigation (highlight_current will also update preview)
   local Navigation = require("okuban.ui.navigation")

--- a/lua/okuban/ui/card.lua
+++ b/lua/okuban/ui/card.lua
@@ -138,28 +138,46 @@ function M.format_compact_metadata(issue, type_tag)
 end
 
 --- Render a single issue as a compact one-line card.
+--- If the issue has a linked worktree (worktree_map provided), shows [WT] badge.
 ---@param issue table { number, title }
 ---@param width integer Available width for text
+---@param worktree_map table<integer, table>|nil Map of issue number → worktree info
 ---@return string
-function M.render_card(issue, width)
+function M.render_card(issue, width, worktree_map)
   local title = M.strip_commit_prefix(issue.title or "")
   local prefix = " #" .. issue.number .. " "
-  local avail = width - #prefix
+
+  -- Check for worktree badge (active worktrees use highlight color instead of badge)
+  local badge = ""
+  if worktree_map and worktree_map[issue.number] then
+    local wt = worktree_map[issue.number]
+    if wt.active then
+      -- No badge — active worktrees are indicated via OkubanCardActive highlight
+      badge = ""
+    elseif wt.dirty then
+      badge = " [\xe2\x97\x8f]" -- U+25CF BLACK CIRCLE (dirty)
+    else
+      badge = " [\xe2\x97\x8b]" -- U+25CB WHITE CIRCLE (clean)
+    end
+  end
+
+  local avail = width - #prefix - #badge
   if avail < 1 then
-    return prefix
+    return prefix .. badge
   end
   if #title > avail then
     title = title:sub(1, avail - 1) .. ELLIPSIS
   end
-  return prefix .. title
+  return prefix .. title .. badge
 end
 
 --- Render all cards for a column as a compact list (one line per card).
 ---@param issues table[] List of issues
 ---@param width integer Available width for text
+---@param worktree_map table<integer, table>|nil Map of issue number → worktree info
 ---@return string[] lines
 ---@return table[] card_ranges Array of { start_line: integer, end_line: integer } (1-indexed)
-function M.render_column(issues, width)
+function M.render_column(issues, width, worktree_map)
   if #issues == 0 then
     return { "  (no issues)" }, {}
   end
@@ -167,19 +185,20 @@ function M.render_column(issues, width)
   local lines = {}
   local card_ranges = {}
   for i, issue in ipairs(issues) do
-    table.insert(lines, M.render_card(issue, width))
+    table.insert(lines, M.render_card(issue, width, worktree_map))
     table.insert(card_ranges, { start_line = i, end_line = i })
   end
   return lines, card_ranges
 end
 
 --- Render preview pane content for the selected issue.
---- Shows full title (word-wrapped), TLDR from body, and metadata.
+--- Shows full title (word-wrapped), TLDR from body, metadata, and worktree status.
 ---@param issue table|nil { number, title, body, assignees, labels }
 ---@param width integer Available width
 ---@param height integer Number of lines in preview pane
+---@param worktree_map table<integer, table>|nil Map of issue number → worktree info
 ---@return string[]
-function M.render_preview(issue, width, height)
+function M.render_preview(issue, width, height, worktree_map)
   if not issue then
     local lines = {}
     for _ = 1, height do
@@ -233,6 +252,25 @@ function M.render_preview(issue, width, height)
   if meta and #lines < height - 1 then
     table.insert(lines, "")
     table.insert(lines, meta)
+  end
+
+  -- Worktree status
+  if worktree_map and worktree_map[issue.number] and #lines < height - 1 then
+    local wt = worktree_map[issue.number]
+    local parts = {}
+    if wt.active then
+      table.insert(parts, "\xe2\xac\xa4 active") -- U+2B24
+    end
+    if wt.dirty then
+      table.insert(parts, "\xe2\x97\x8f dirty") -- U+25CF
+    else
+      table.insert(parts, "\xe2\x97\x8b clean") -- U+25CB
+    end
+    if wt.branch then
+      table.insert(parts, wt.branch)
+    end
+    table.insert(lines, "")
+    table.insert(lines, table.concat(parts, " \xc2\xb7 "))
   end
 
   -- Pad to height

--- a/lua/okuban/worktree.lua
+++ b/lua/okuban/worktree.lua
@@ -1,0 +1,127 @@
+local detect = require("okuban.detect")
+
+local M = {}
+
+--- Parse the output of `git worktree list --porcelain` into structured data.
+---@param output string Raw output from git worktree list --porcelain
+---@return table[] worktrees Array of { path, head, branch, bare, detached }
+function M.parse_porcelain(output)
+  if not output or output == "" then
+    return {}
+  end
+
+  local worktrees = {}
+  local current = {}
+
+  for line in (output .. "\n"):gmatch("([^\n]*)\n") do
+    if line == "" then
+      if current.path then
+        table.insert(worktrees, current)
+      end
+      current = {}
+    elseif line:match("^worktree ") then
+      current.path = line:sub(10)
+    elseif line:match("^HEAD ") then
+      current.head = line:sub(6)
+    elseif line:match("^branch ") then
+      -- Strip refs/heads/ prefix
+      local branch = line:sub(8)
+      current.branch = branch:gsub("^refs/heads/", "")
+    elseif line == "bare" then
+      current.bare = true
+    elseif line == "detached" then
+      current.detached = true
+    end
+  end
+
+  -- Handle last entry if no trailing newline
+  if current.path then
+    table.insert(worktrees, current)
+  end
+
+  return worktrees
+end
+
+--- Map worktrees to issue numbers using branch name detection.
+--- Returns a table keyed by issue number.
+---@param worktrees table[] Parsed worktree list
+---@return table<integer, table> map { [issue_number] = { path, branch, ... } }
+function M.map_to_issues(worktrees)
+  local map = {}
+  for _, wt in ipairs(worktrees) do
+    if wt.branch and not wt.bare then
+      local num = detect.parse_branch_name(wt.branch)
+      if num then
+        map[num] = wt
+      end
+    end
+  end
+  return map
+end
+
+--- Fetch the list of worktrees and map them to issue numbers.
+--- Synchronous (~4ms).
+---@return table<integer, table> map { [issue_number] = { path, branch, dirty, active } }
+function M.fetch_worktree_map()
+  local result = vim.system({ "git", "worktree", "list", "--porcelain" }, { text = true }):wait()
+  if result.code ~= 0 or not result.stdout then
+    return {}
+  end
+
+  local worktrees = M.parse_porcelain(result.stdout)
+  local map = M.map_to_issues(worktrees)
+
+  -- Mark the active worktree (matches current cwd)
+  local cwd = vim.fn.getcwd()
+  for _, wt in pairs(map) do
+    wt.active = (wt.path == cwd)
+  end
+
+  return map
+end
+
+--- Check dirty/clean status of a single worktree (async).
+---@param path string Worktree path
+---@param callback fun(dirty: boolean)
+function M.check_dirty(path, callback)
+  vim.system({ "git", "-C", path, "status", "--porcelain" }, { text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        callback(false)
+        return
+      end
+      local dirty = result.stdout and result.stdout:match("%S") ~= nil
+      callback(dirty)
+    end)
+  end)
+end
+
+--- Fetch worktree map and enrich with dirty/clean status (async).
+--- Calls callback with the fully enriched map.
+---@param callback fun(map: table<integer, table>)
+function M.fetch_enriched(callback)
+  local map = M.fetch_worktree_map()
+
+  -- Count how many worktrees need status checks
+  local pending = 0
+  for _ in pairs(map) do
+    pending = pending + 1
+  end
+
+  if pending == 0 then
+    callback(map)
+    return
+  end
+
+  for _, wt in pairs(map) do
+    M.check_dirty(wt.path, function(dirty)
+      wt.dirty = dirty
+      pending = pending - 1
+      if pending == 0 then
+        callback(map)
+      end
+    end)
+  end
+end
+
+return M

--- a/tests/test_card_render_spec.lua
+++ b/tests/test_card_render_spec.lua
@@ -224,6 +224,43 @@ describe("okuban.ui.card", function()
       assert.truthy(result:match("#12345"))
       assert.truthy(result:match("Big"))
     end)
+
+    it("shows worktree badge when worktree exists", function()
+      local wt_map = { [42] = { path = "/wt", branch = "feat/issue-42", dirty = false } }
+      local result = card_mod.render_card({ number = 42, title = "Test" }, 40, wt_map)
+      -- Should contain circle indicator
+      assert.truthy(result:match("\xe2\x97\x8b")) -- U+25CB WHITE CIRCLE (clean)
+    end)
+
+    it("shows dirty badge for dirty worktree", function()
+      local wt_map = { [42] = { path = "/wt", branch = "feat/issue-42", dirty = true } }
+      local result = card_mod.render_card({ number = 42, title = "Test" }, 40, wt_map)
+      assert.truthy(result:match("\xe2\x97\x8f")) -- U+25CF BLACK CIRCLE (dirty)
+    end)
+
+    it("no badge for active worktree (uses highlight instead)", function()
+      local wt_map = { [42] = { path = "/wt", branch = "feat/issue-42", active = true } }
+      local result = card_mod.render_card({ number = 42, title = "Test" }, 40, wt_map)
+      -- Active worktrees use OkubanCardActive highlight, no badge
+      assert.is_falsy(result:match("\xe2\xac\xa4")) -- No U+2B24
+      assert.is_falsy(result:match("\xe2\x97\x8b")) -- No U+25CB
+      assert.is_falsy(result:match("\xe2\x97\x8f")) -- No U+25CF
+      assert.truthy(result:match("Test")) -- Title still present
+    end)
+
+    it("no badge when issue not in worktree map", function()
+      local wt_map = { [99] = { path = "/wt", branch = "feat/issue-99" } }
+      local result = card_mod.render_card({ number = 42, title = "Test" }, 40, wt_map)
+      assert.is_falsy(result:match("\xe2\x97\x8b"))
+      assert.is_falsy(result:match("\xe2\x97\x8f"))
+      assert.is_falsy(result:match("\xe2\xac\xa4"))
+    end)
+
+    it("no badge when worktree_map is nil", function()
+      local result = card_mod.render_card({ number = 42, title = "Test" }, 40, nil)
+      assert.is_falsy(result:match("\xe2\x97\x8b"))
+      assert.is_falsy(result:match("\xe2\x97\x8f"))
+    end)
   end)
 
   describe("render_column", function()

--- a/tests/test_worktree_spec.lua
+++ b/tests/test_worktree_spec.lua
@@ -1,0 +1,236 @@
+local helpers = require("tests.helpers")
+
+describe("okuban.worktree", function()
+  local wt
+
+  before_each(function()
+    package.loaded["okuban.worktree"] = nil
+    package.loaded["okuban.detect"] = nil
+    package.loaded["okuban.config"] = nil
+    wt = require("okuban.worktree")
+  end)
+
+  after_each(function()
+    helpers.restore_vim_system()
+  end)
+
+  describe("parse_porcelain", function()
+    it("parses a single worktree entry", function()
+      local output = table.concat({
+        "worktree /home/user/project",
+        "HEAD abc123",
+        "branch refs/heads/main",
+        "",
+      }, "\n")
+
+      local result = wt.parse_porcelain(output)
+      assert.equals(1, #result)
+      assert.equals("/home/user/project", result[1].path)
+      assert.equals("abc123", result[1].head)
+      assert.equals("main", result[1].branch)
+    end)
+
+    it("parses multiple worktree entries", function()
+      local output = table.concat({
+        "worktree /home/user/project",
+        "HEAD abc123",
+        "branch refs/heads/main",
+        "",
+        "worktree /home/user/project-wt1",
+        "HEAD def456",
+        "branch refs/heads/feat/issue-42-login",
+        "",
+      }, "\n")
+
+      local result = wt.parse_porcelain(output)
+      assert.equals(2, #result)
+      assert.equals("feat/issue-42-login", result[2].branch)
+    end)
+
+    it("handles bare worktree", function()
+      local output = table.concat({
+        "worktree /home/user/project.git",
+        "HEAD abc123",
+        "bare",
+        "",
+      }, "\n")
+
+      local result = wt.parse_porcelain(output)
+      assert.equals(1, #result)
+      assert.is_true(result[1].bare)
+      assert.is_nil(result[1].branch)
+    end)
+
+    it("handles detached HEAD", function()
+      local output = table.concat({
+        "worktree /home/user/project-wt",
+        "HEAD abc123",
+        "detached",
+        "",
+      }, "\n")
+
+      local result = wt.parse_porcelain(output)
+      assert.equals(1, #result)
+      assert.is_true(result[1].detached)
+    end)
+
+    it("returns empty for empty input", function()
+      assert.equals(0, #wt.parse_porcelain(""))
+    end)
+
+    it("returns empty for nil input", function()
+      assert.equals(0, #wt.parse_porcelain(nil))
+    end)
+
+    it("strips refs/heads/ prefix from branch", function()
+      local output = "worktree /path\nHEAD abc\nbranch refs/heads/feat/issue-7-fix\n\n"
+      local result = wt.parse_porcelain(output)
+      assert.equals("feat/issue-7-fix", result[1].branch)
+    end)
+  end)
+
+  describe("map_to_issues", function()
+    it("maps worktrees to issue numbers via branch name", function()
+      local worktrees = {
+        { path = "/main", branch = "main" },
+        { path = "/wt1", branch = "feat/issue-42-login" },
+        { path = "/wt2", branch = "fix/issue-7-null" },
+      }
+
+      local map = wt.map_to_issues(worktrees)
+      assert.is_not_nil(map[42])
+      assert.equals("/wt1", map[42].path)
+      assert.is_not_nil(map[7])
+      assert.equals("/wt2", map[7].path)
+      assert.is_nil(map[1]) -- main has no issue number
+    end)
+
+    it("skips bare worktrees", function()
+      local worktrees = {
+        { path = "/bare", branch = "feat/issue-42", bare = true },
+      }
+
+      local map = wt.map_to_issues(worktrees)
+      assert.is_nil(map[42])
+    end)
+
+    it("skips worktrees without branch", function()
+      local worktrees = {
+        { path = "/detached", detached = true },
+      }
+
+      local map = wt.map_to_issues(worktrees)
+      -- Should have no entries
+      local count = 0
+      for _ in pairs(map) do
+        count = count + 1
+      end
+      assert.equals(0, count)
+    end)
+
+    it("returns empty map for empty input", function()
+      local map = wt.map_to_issues({})
+      local count = 0
+      for _ in pairs(map) do
+        count = count + 1
+      end
+      assert.equals(0, count)
+    end)
+  end)
+
+  describe("fetch_worktree_map", function()
+    it("parses git worktree list output", function()
+      helpers.mock_vim_system({
+        {
+          code = 0,
+          stdout = table.concat({
+            "worktree /home/user/project",
+            "HEAD abc",
+            "branch refs/heads/main",
+            "",
+            "worktree /home/user/wt-42",
+            "HEAD def",
+            "branch refs/heads/feat/issue-42-login",
+            "",
+          }, "\n"),
+        },
+      })
+
+      local map = wt.fetch_worktree_map()
+      assert.is_not_nil(map[42])
+      assert.equals("/home/user/wt-42", map[42].path)
+    end)
+
+    it("returns empty map on git error", function()
+      helpers.mock_vim_system({
+        { code = 128, stderr = "not a git repo" },
+      })
+
+      local map = wt.fetch_worktree_map()
+      local count = 0
+      for _ in pairs(map) do
+        count = count + 1
+      end
+      assert.equals(0, count)
+    end)
+  end)
+
+  describe("check_dirty", function()
+    it("reports dirty when status has output", function()
+      helpers.mock_vim_system({
+        { code = 0, stdout = " M file.lua\n" },
+      })
+
+      local done = false
+      local result = nil
+      wt.check_dirty("/some/path", function(dirty)
+        done = true
+        result = dirty
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+
+      assert.is_true(result)
+    end)
+
+    it("reports clean when status is empty", function()
+      helpers.mock_vim_system({
+        { code = 0, stdout = "" },
+      })
+
+      local done = false
+      local result = nil
+      wt.check_dirty("/some/path", function(dirty)
+        done = true
+        result = dirty
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+
+      assert.is_false(result)
+    end)
+
+    it("reports clean on git error", function()
+      helpers.mock_vim_system({
+        { code = 1, stderr = "error" },
+      })
+
+      local done = false
+      local result = nil
+      wt.check_dirty("/some/path", function(dirty)
+        done = true
+        result = dirty
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+
+      assert.is_false(result)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Show per-card worktree indicators: orange text for active worktrees (via `OkubanCardActive` highlight), `[●]` badge for dirty, `[○]` badge for clean
- Preview pane shows full worktree status with active/dirty/clean indicator and branch name
- Two-phase rendering: sync fetch for instant badges (~4ms), async enrichment for dirty/clean status with automatic re-render
- New `lua/okuban/worktree.lua` module: parse `git worktree list --porcelain`, map branches to issue numbers, check dirty status

Fixes #22

## Test plan
- [x] 16 new worktree tests (parse_porcelain, map_to_issues, fetch_worktree_map, check_dirty)
- [x] 5 new card render tests (worktree badges: clean, dirty, active=no badge, not in map, nil map)
- [x] All 192 tests pass, lint clean
- [ ] Manual: `:Okuban` shows orange text on active worktree card
- [ ] Manual: dirty/clean badges appear on non-active worktree cards
- [ ] Manual: preview shows full worktree status section

🤖 Generated with [Claude Code](https://claude.com/claude-code)