### PR TITLE
docs: comprehensive documentation overhaul

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,46 @@
+---
+name: Bug Report
+about: Report something that isn't working correctly
+title: ""
+labels: "type: bug"
+assignees: ""
+---
+
+## Describe the Bug
+
+A clear description of what the bug is.
+
+## Steps to Reproduce
+
+1. Open Neovim
+2. Run `:Okuban`
+3. ...
+4. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include error messages or screenshots if possible.
+
+## Environment
+
+- **Neovim version**: `nvim --version`
+- **okuban.nvim version/commit**:
+- **gh CLI version**: `gh --version`
+- **OS**:
+
+## Config
+
+```lua
+-- Your okuban setup (if non-default)
+require("okuban").setup({
+  -- ...
+})
+```
+
+## Additional Context
+
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea or improvement
+title: ""
+labels: "type: feature"
+assignees: ""
+---
+
+## Problem
+
+What problem does this feature solve? What's the use case?
+
+## Proposed Solution
+
+How should this work? Describe the desired behavior.
+
+## Alternatives Considered
+
+What other approaches did you consider? Why is the proposed solution preferred?
+
+## Additional Context
+
+Any mockups, references to other plugins, or other context.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- Brief description of the changes. What does this PR do and why? -->
+
+Fixes #<!-- issue number -->
+
+## Changes
+
+-
+
+## Checklist
+
+- [ ] Linked to a GitHub issue (`Fixes #...` or `Closes #...`)
+- [ ] Tests pass (`make check`)
+- [ ] Lint clean (`make lint`)
+- [ ] Docs updated (if user-facing change)
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,173 @@
+# Contributing to okuban.nvim
+
+Thanks for your interest in contributing! This guide covers everything you need to get started.
+
+## Prerequisites
+
+- **Neovim 0.10+** — [Install instructions](https://github.com/neovim/neovim/blob/master/INSTALL.md)
+- **GitHub CLI** (`gh`) — [Install](https://cli.github.com), then `gh auth login`
+- **StyLua** — `cargo install stylua` or `brew install stylua`
+- **Luacheck** — `luarocks install luacheck` or `brew install luacheck`
+- **plenary.nvim** — Installed automatically for tests via `tests/minimal_init.lua`
+
+## Development Setup
+
+```bash
+# Clone the repo
+git clone https://github.com/khwerhahn/okuban.nvim.git
+cd okuban.nvim
+
+# Run the full CI check locally
+make check
+```
+
+### Makefile Targets
+
+| Command | What it does |
+|---------|-------------|
+| `make test` | Run plenary.nvim tests (Neovim headless) |
+| `make lint` | Run StyLua check + Luacheck |
+| `make check` | Run lint + test (same as CI) |
+| `make format` | Auto-format with StyLua |
+
+## Code Style
+
+- **Formatter**: StyLua (configured in `.stylua.toml`) — 2-space indent, 120 column width
+- **Linter**: Luacheck (configured in `.luacheckrc`) — `vim` is a known global
+- **File size limit**: 500 lines maximum per file. If a file approaches this, refactor.
+- Run `make lint` before committing to catch issues early.
+
+## Testing
+
+Tests use [plenary.nvim](https://github.com/nvim-lua/plenary.nvim) with busted-style syntax.
+
+### Running Tests
+
+```bash
+# All tests
+make test
+
+# Single file
+nvim --headless -c "PlenaryBustedFile tests/test_config_spec.lua"
+```
+
+### Writing Tests
+
+- Test files go in `tests/` and must end with `_spec.lua`
+- Use `describe` / `it` / `before_each` / `after_each` blocks
+- Mock `vim.system()` for tests that call external commands (see `tests/helpers.lua`)
+- Aim for test-driven development: write tests alongside code
+
+### Test File Index
+
+| File | What it tests |
+|------|--------------|
+| `test_config_spec.lua` | Config defaults and label system |
+| `test_api_spec.lua` | Preflight checks |
+| `test_api_fetch_spec.lua` | Fetch, parse, and label creation |
+| `test_board_layout_spec.lua` | Layout calculations |
+| `test_card_render_spec.lua` | Card formatting and worktree badges |
+| `test_navigation_spec.lua` | Navigation state and focus |
+| `test_move_spec.lua` | Move command |
+| `test_integration_spec.lua` | Full flow integration |
+| `test_actions_spec.lua` | Action menu |
+| `test_detect_spec.lua` | Issue detection cascade |
+| `test_worktree_spec.lua` | Worktree parsing and mapping |
+| `test_claude_spec.lua` | Claude module |
+
+## Pull Request Process
+
+### 1. Find or Create an Issue
+
+All work must be tracked through a GitHub issue. Check [existing issues](https://github.com/khwerhahn/okuban.nvim/issues) or create a new one.
+
+### 2. Create a Feature Branch
+
+```bash
+git checkout main
+git pull
+git checkout -b <type>/issue-<NUMBER>-<short-description>
+```
+
+Branch naming: `feat/issue-42-board-rendering`, `fix/issue-15-label-sync`, `docs/issue-7-readme`
+
+### 3. Make Your Changes
+
+- Write tests alongside your code
+- Run `make check` before committing
+- Keep commits focused and atomic
+
+### 4. Commit with Issue Reference
+
+```bash
+git commit -m "feat(ui): add board column rendering (Fixes #42)"
+```
+
+Format: `<type>(<scope>): <description> (<keyword> #<issue>)`
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+
+Keywords: `Fixes #N` (auto-closes on merge), `Refs #N` (reference only)
+
+### 5. Push and Open a PR
+
+```bash
+git push -u origin <branch-name>
+gh pr create
+```
+
+- PR title must follow [Conventional Commits](https://www.conventionalcommits.org/) format (enforced in CI)
+- PR body must include `Fixes #<NUMBER>` or `Closes #<NUMBER>`
+
+### 6. CI Must Pass
+
+The following checks run on every PR:
+- StyLua formatting check
+- Luacheck linting
+- plenary.nvim tests on Neovim stable + nightly
+- PR title lint (conventional commit format)
+
+All checks must pass before the PR can be merged.
+
+## Architecture Overview
+
+```
+lua/okuban/
+├── init.lua          # Plugin entry point: setup(), open(), close(), refresh()
+├── config.lua        # User configuration, defaults, deep merge
+├── api.lua           # GitHub operations via gh CLI (preflight, fetch, edit, close)
+├── detect.lua        # Issue detection from branch/commits/gh CLI
+├── worktree.lua      # Git worktree listing, status checks, mapping
+├── claude.lua        # Claude Code session management (launch, track, parse)
+├── utils.lua         # Notifications and helper functions
+└── ui/
+    ├── board.lua     # Kanban board layout, window management, polling
+    ├── card.lua      # Card rendering, preview pane content
+    ├── navigation.lua # Cursor movement, focus, highlight management
+    ├── actions.lua   # Action menu popup (move, view, close, assign, code)
+    ├── move.lua      # Column picker for moving cards
+    └── help.lua      # Help overlay
+```
+
+### Data Flow
+
+1. `init.open()` runs preflight checks via `api.preflight()`
+2. `api.fetch_all_columns()` queries `gh issue list` per configured column
+3. `board.lua` creates floating windows and renders cards via `card.lua`
+4. `navigation.lua` manages cursor state and highlights
+5. User actions trigger `api.lua` calls which update labels/state on GitHub
+6. Auto-polling re-fetches data and refreshes the board in place
+
+## Issue-Driven Development
+
+This project enforces issue-driven development through three layers:
+
+1. **CLAUDE.md** — Project instructions (guidance)
+2. **Hooks** — Automated enforcement (blocks commits without issue refs)
+3. **Skills** — Workflow automation (`/start-issue`, `/close-issue`)
+
+If you're using Claude Code, these work automatically. If not, just make sure every commit references an issue number.
+
+## Questions?
+
+Open a [GitHub issue](https://github.com/khwerhahn/okuban.nvim/issues/new) or check the [FAQ in the README](README.md#faq).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A Neovim plugin that turns GitHub issues into an interactive kanban board inside
 
 ## Status
 
-**Early Development** — Not yet functional. See [Roadmap](#roadmap) below.
+**Beta** — Actively developed. Core features are functional. See [Roadmap](#roadmap) for what's shipped and what's coming.
 
 ## Why?
 
@@ -41,12 +41,20 @@ Issues without an `okuban:` label appear in an **Unsorted** column.
 
 Moving a card between columns swaps labels automatically. No GitHub Projects board needed.
 
+## Features
+
+- **Preview pane** — Issue details (title, labels, assignees, body excerpt) displayed below the board. Automatically updates as you navigate between cards.
+- **Auto-polling** — The board refreshes from GitHub every 20 seconds (configurable, or disable with `poll_interval = 0`).
+- **Auto-focus** — On board open, okuban detects which issue you're working on from your git branch name, recent commit messages, or the `gh` CLI, and scrolls to that card. Press `g` to re-trigger.
+- **Worktree status badges** — Cards show git worktree indicators: `○` (worktree exists, clean), `●` (worktree exists, dirty). The card for your active worktree is highlighted in orange.
+- **Action menu** — Press `<CR>` on any card to open a floating menu with actions: move, view in browser, close, assign, or launch Claude Code.
+- **Claude Code integration** — Launch autonomous Claude Code sessions directly from the board. Each session runs in its own git worktree with sandboxed tools and budget limits.
+
 ## Prerequisites
 
 - Neovim 0.10+
 - [GitHub CLI](https://cli.github.com) (`gh`) — installed and authenticated
-- [jq](https://jqlang.github.io/jq/) — for Claude Code hook enforcement (`brew install jq`)
-- [Claude Code](https://claude.ai) (`claude`) — optional, only for autonomous coding feature
+- [Claude Code](https://claude.ai/code) (`claude`) — optional, only for autonomous coding feature
 
 ## Installation
 
@@ -81,6 +89,8 @@ Plug 'khwerhahn/okuban.nvim'
 
 ## Configuration
 
+All options with their defaults:
+
 ```lua
 require("okuban").setup({
   -- Label-to-column mapping (order = left-to-right on the board)
@@ -89,26 +99,63 @@ require("okuban").setup({
     { label = "okuban:todo",        name = "Todo",        color = "#0075ca" },
     { label = "okuban:in-progress", name = "In Progress", color = "#fbca04" },
     { label = "okuban:review",      name = "Review",      color = "#d4c5f9" },
-    { label = "okuban:done",        name = "Done",        color = "#0e8a16" },
+    { label = "okuban:done",        name = "Done",        color = "#0e8a16", state = "all", limit = 20 },
   },
 
   -- Show a column for issues without any okuban: label
   show_unsorted = true,
 
-  -- Skip preflight checks (for users who know their setup works)
+  -- Skip preflight checks (gh auth, repo scope)
   skip_preflight = false,
 
-  -- GitHub hostname (for Enterprise Server users)
+  -- GitHub hostname (for GitHub Enterprise Server)
   github_hostname = nil,
 
-  -- Claude Code settings (optional)
+  -- Height of the preview pane below the board (0 to disable)
+  preview_lines = 8,
+
+  -- Show TLDR excerpt from issue body in the preview pane
+  show_tldr = true,
+
+  -- Auto-refresh interval in seconds (0 to disable)
+  poll_interval = 20,
+
+  -- Board keymaps (all buffer-local to the board windows)
+  keymaps = {
+    column_left  = "h",
+    column_right = "l",
+    card_up      = "k",
+    card_down    = "j",
+    move_card    = "m",
+    open_actions = "<CR>",
+    goto_current = "g",
+    close        = "q",
+    refresh      = "r",
+    help         = "?",
+  },
+
+  -- Claude Code integration (requires `claude` CLI)
   claude = {
     enabled = true,
     max_budget_usd = 5.00,
     max_turns = 30,
+    allowed_tools = {
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
+    },
+    worktree_base_dir = nil,  -- nil = auto (../repo-worktrees/)
+    auto_push = false,        -- push worktree branch on session complete
+    auto_pr = false,          -- create PR on session complete
   },
 })
 ```
+
+The Done column uses `state = "all"` to include closed issues and `limit = 20` to cap how many are fetched (for performance). Both are configurable per column.
 
 ## Commands
 
@@ -124,26 +171,31 @@ require("okuban").setup({
 
 ### Board Navigation
 
+All keybindings are buffer-local to the board windows and configurable via the `keymaps` option.
+
 | Key | Action |
 |-----|--------|
 | `h` / `l` | Move between columns |
 | `j` / `k` | Move between cards |
 | `<CR>` | Open action menu on selected card |
 | `m` | Move card to another column |
-| `n` | New draft issue |
-| `r` | Refresh board |
 | `g` | Jump to auto-detected current issue |
+| `r` | Refresh board |
 | `q` | Close board |
 | `?` | Show help |
 
 ### Action Menu
 
+Press `<CR>` on any card to open the action menu:
+
 | Key | Action |
 |-----|--------|
-| `a` | View issue in browser |
-| `b` | Close issue (with confirmation) |
-| `c` | Code autonomously (worktree + Claude) |
-| `<Esc>` / `q` | Dismiss menu |
+| `m` | Move to column |
+| `v` | View in browser |
+| `c` | Close issue (open issues only) |
+| `a` | Assign to me (open issues only) |
+| `x` | Code with Claude (open issues, when available) |
+| `q` / `<Esc>` | Dismiss menu |
 
 ## Label Setup
 
@@ -153,40 +205,114 @@ See [docs/label-setup.md](docs/label-setup.md) for the full label reference with
 
 ## Roadmap
 
-### Beta — Core Board (label-based)
-- [ ] Preflight checks (gh auth, repo scope)
-- [ ] `:OkubanSetup` to create default labels
-- [ ] Fetch issues per label column via `gh issue list`
-- [ ] Multi-column floating window layout with sticky headers
-- [ ] Semantic hjkl navigation between columns and cards
-- [ ] Move cards between columns (label swap via `gh issue edit`)
+### Phase 1: Core Board
+- [x] Preflight checks (gh auth, repo scope)
+- [x] `:OkubanSetup` to create default labels
+- [x] Fetch issues per label column via `gh issue list`
+- [x] Multi-column floating window layout with sticky headers
+- [x] Semantic hjkl navigation between columns and cards
+- [x] Move cards between columns (label swap via `gh issue edit`)
 
-### Beta — Smart Features
-- [ ] Auto-focus on current issue from git branch/commit context
-- [ ] Worktree status indicators per card (exists, dirty, active, ahead/behind)
-- [ ] Action menu on cards (view in browser, close, code)
-- [ ] Card detail view (issue body, comments, labels)
+### Phase 2: Smart Features
+- [x] Auto-focus on current issue from git branch/commit context
+- [x] Worktree status indicators per card (exists, dirty, active)
+- [x] Action menu on cards (view, close, assign, code)
+- [x] Preview pane with issue details below the board
 
-### Beta — Autonomous Coding
-- [ ] Launch Claude Code sessions from the board
-- [ ] Git worktree creation and management for isolated coding
-- [ ] Monitor running Claude sessions with live status
+### Phase 3: Autonomous Coding
+- [x] Launch Claude Code sessions from the board
+- [x] Git worktree creation and management for isolated coding
+- [x] Monitor running Claude sessions with live status badges
 
-### Beta — Polish & Community
+### Phase 4: Polish & Community
 - [ ] Telescope integration for repo picker
 - [ ] Customizable colors and highlight groups
 - [ ] Status line integration
 - [x] GitHub Actions CI (tests, StyLua, Luacheck)
-- [ ] Issue templates, PR template, CONTRIBUTING.md
+- [x] Issue templates, PR template, CONTRIBUTING.md
 
-### v1.0 — GitHub Projects v2
+### v1.0: GitHub Projects v2
 - [ ] GitHub Projects v2 as an alternative/additional data source (GraphQL API)
 - [ ] Custom field support (priority, iteration, size)
 - [ ] Sync between labels and project board columns
 
-## Development
+## FAQ
 
-### Running locally
+**Do I need GitHub Projects?**
+No. okuban.nvim uses GitHub issue labels as its data source. You only need issues and labels — no Projects board setup required.
+
+**Can I customize the columns?**
+Yes. Pass a `columns` table to `setup()` with your own labels, names, and colors:
+```lua
+require("okuban").setup({
+  columns = {
+    { label = "status:new",  name = "New",  color = "#c5def5" },
+    { label = "status:wip",  name = "WIP",  color = "#fbca04" },
+    { label = "status:done", name = "Done", color = "#0e8a16", state = "all", limit = 50 },
+  },
+})
+```
+
+**How does auto-focus work?**
+When you open the board, okuban tries to detect which issue you're working on using a three-tier cascade:
+1. **Branch name** — Parses patterns like `feat/issue-42-description`, `fix/123-null-check`, or `GH-42-oauth`
+2. **Recent commits** — Scans the last 5 commit messages for `#N` references
+3. **gh CLI** — Queries for issues assigned to you with the `okuban:in-progress` label
+
+Press `g` at any time to re-run detection and jump to the matched card.
+
+**What are the worktree badges?**
+Cards show git worktree status when a linked worktree exists:
+- `○` — worktree exists, working tree is clean
+- `●` — worktree exists, working tree has uncommitted changes
+- Orange highlight — this is your currently active worktree
+
+**How does Claude Code integration work?**
+From the action menu (`<CR>` then `x`), okuban creates a separate git worktree for the issue, fetches the issue context, and launches Claude Code with sandboxed tools and a budget cap. The session runs autonomously while you continue working. Session status is shown as badges on cards: `[▶]` running, `[✓]` completed, `[✗]` failed.
+
+**Can I use this with GitHub Enterprise?**
+Yes. Set the `github_hostname` option:
+```lua
+require("okuban").setup({
+  github_hostname = "github.mycompany.com",
+})
+```
+
+**How do I disable auto-polling?**
+Set `poll_interval` to 0:
+```lua
+require("okuban").setup({
+  poll_interval = 0,
+})
+```
+
+**Why is the Done column limited to 20 issues?**
+The Done column includes closed issues (`state = "all"`), which can grow large over time. The default `limit = 20` keeps the board responsive. You can change this per column:
+```lua
+columns = {
+  -- ...
+  { label = "okuban:done", name = "Done", color = "#0e8a16", state = "all", limit = 100 },
+},
+```
+
+## Troubleshooting
+
+**"gh CLI not found"**
+Install from https://cli.github.com, then run `gh auth login`.
+
+**"Not authenticated with GitHub"**
+Run `gh auth login` and follow the prompts.
+
+**"Labels not showing up"**
+Run `:OkubanSetup` to create the default labels, then assign them to your issues.
+
+**"Claude Code not available"**
+Install Claude Code from https://claude.ai/code. This is optional — the board works fully without it.
+
+**Board looks wrong after resizing the terminal**
+The board automatically repositions on `VimResized`, but if something looks off, press `r` to refresh or reopen with `:Okuban`.
+
+## Development
 
 ```bash
 # Run tests
@@ -202,28 +328,11 @@ make check
 make format
 ```
 
-### CI
-
-Every push to `main` and every PR runs:
-- **StyLua** formatting check
-- **Luacheck** linting
-- **plenary.nvim tests** on Neovim stable + nightly
-- **PR title lint** — must follow [Conventional Commits](https://www.conventionalcommits.org/) format
-
-Branch protection requires all checks to pass before merging.
-
-### Releases
-
-Versioning follows [SemVer](https://semver.org/) with `v`-prefixed tags. [release-please](https://github.com/googleapis/release-please) automates version bumps and changelogs based on Conventional Commits.
-
-On each release:
-- A `v*` tag and GitHub Release are created automatically
-- The `stable` tag is updated (for `version = "*"` in lazy.nvim)
-- The plugin is published to [LuaRocks](https://luarocks.org/)
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development guide.
 
 ## Contributing with Claude Code
 
-This project is built with Claude Code and ships with a complete AI-assisted development workflow. When you clone or fork the repo, you get:
+This project ships with a Claude Code workflow. When you clone or fork the repo, you get:
 
 **Custom skills** (slash commands):
 | Command | What it does |
@@ -237,36 +346,13 @@ This project is built with Claude Code and ships with a complete AI-assisted dev
 - Commits without an issue reference (`Fixes #42`, `Refs #42`) are **blocked**
 - Session start auto-detects which issue you're working on from the branch name
 
-**Issue-driven development** — all work must have a GitHub issue:
-```
-/start-issue 42              # Begin work (branch, assign, label)
-# ... write code ...
-git commit -m "feat(ui): add board rendering (Fixes #42)"
-gh pr create --body "Fixes #42"
-/close-issue 42              # Done (label, comment, close)
-```
-
 See [docs/claude-code-workflow.md](docs/claude-code-workflow.md) for the full guide.
-
-## Troubleshooting
-
-**"gh CLI not found"**
-Install from https://cli.github.com, then run `gh auth login`.
-
-**"Not authenticated with GitHub"**
-Run `gh auth login` and follow the prompts.
-
-**"Labels not showing up"**
-Run `:OkubanSetup` to create the default labels, then assign them to your issues.
-
-**"Claude Code not available"**
-Install Claude Code from https://claude.ai. This is optional — the board works fully without it.
 
 ## Design Docs
 
 - [Feature Architecture](docs/feature-architecture.md) — Detailed design for all core features
 - [Label Setup](docs/label-setup.md) — Full label reference with colors, descriptions, and `gh` commands
-- [Claude Code Workflow](docs/claude-code-workflow.md) — How to use Claude Code with this project: skills, hooks, issue-driven development
+- [Claude Code Workflow](docs/claude-code-workflow.md) — How to use Claude Code with this project
 
 ## License
 

--- a/doc/okuban.txt
+++ b/doc/okuban.txt
@@ -13,13 +13,18 @@ CONTENTS                                                     *okuban-contents*
   4. Commands .......................... |okuban-commands|
   5. Keybindings ....................... |okuban-keybindings|
   6. Configuration ..................... |okuban-configuration|
+  7. Features .......................... |okuban-features|
+  8. FAQ ............................... |okuban-faq|
+  9. Troubleshooting ................... |okuban-troubleshooting|
 
 ==============================================================================
 1. INTRODUCTION                                          *okuban-introduction*
 
 okuban.nvim turns GitHub issues into an interactive kanban board inside
 Neovim. Issues are sorted into columns based on labels with the `okuban:`
-prefix. No GitHub Projects setup required.
+prefix. No GitHub Projects setup required — just issues and labels.
+
+Moving a card between columns swaps labels automatically via `gh issue edit`.
 
 ==============================================================================
 2. REQUIREMENTS                                          *okuban-requirements*
@@ -27,6 +32,7 @@ prefix. No GitHub Projects setup required.
 - Neovim 0.10+
 - `gh` CLI (https://cli.github.com) — installed and authenticated
 - `repo` scope (default in `gh auth login`)
+- `claude` CLI — optional, only for autonomous coding feature
 
 ==============================================================================
 3. SETUP                                                       *okuban-setup*
@@ -34,7 +40,7 @@ prefix. No GitHub Projects setup required.
 Using lazy.nvim: >lua
   {
     "khwerhahn/okuban.nvim",
-    cmd = { "Okuban", "OkubanSetup", "OkubanRefresh", "OkubanClose" },
+    cmd = { "Okuban", "OkubanSetup" },
     opts = {},
   }
 <
@@ -57,7 +63,7 @@ Then run `:OkubanSetup` to create the kanban labels on your repo.
   Create kanban labels on the current repository.
   Without arguments: creates 5 column labels (okuban:backlog, okuban:todo,
   okuban:in-progress, okuban:review, okuban:done).
-  With `--full`: also creates type, priority, and community labels (~17 total).
+  With `--full`: also creates type, priority, and community labels.
 
 ==============================================================================
 5. KEYBINDINGS                                           *okuban-keybindings*
@@ -65,15 +71,32 @@ Then run `:OkubanSetup` to create the kanban labels on your repo.
 All keybindings are buffer-local to the board windows and configurable
 via the `keymaps` option in |okuban-configuration|.
 
-  Key   Action ~
-  h     Move to previous column
-  l     Move to next column
-  k     Move to previous card
-  j     Move to next card
-  m     Move card to another column
-  r     Refresh board
-  ?     Toggle help
-  q     Close board
+Board Navigation ~
+
+  Key       Action ~
+  h         Move to previous column
+  l         Move to next column
+  k         Move to previous card
+  j         Move to next card
+  m         Move card to another column
+  <CR>      Open action menu on selected card
+  g         Jump to auto-detected current issue
+  r         Refresh board
+  ?         Toggle help
+  q         Close board
+
+Action Menu ~
+
+Press `<CR>` on any card to open the action menu. Available actions depend
+on the issue state.
+
+  Key       Action ~
+  m         Move to column (always available)
+  v         View in browser (always available)
+  c         Close issue (open issues only)
+  a         Assign to me (open issues only)
+  x         Code with Claude (open issues, when claude is available)
+  q/<Esc>   Dismiss menu
 
 ==============================================================================
 6. CONFIGURATION                                       *okuban-configuration*
@@ -85,17 +108,23 @@ Pass options to `setup()`: >lua
       { label = "okuban:todo",        name = "Todo",        color = "#0075ca" },
       { label = "okuban:in-progress", name = "In Progress", color = "#fbca04" },
       { label = "okuban:review",      name = "Review",      color = "#d4c5f9" },
-      { label = "okuban:done",        name = "Done",        color = "#0e8a16" },
+      { label = "okuban:done",        name = "Done",        color = "#0e8a16",
+                                       state = "all", limit = 20 },
     },
     show_unsorted = true,
     skip_preflight = false,
     github_hostname = nil,
+    preview_lines = 8,
+    show_tldr = true,
+    poll_interval = 20,
     keymaps = {
       column_left  = "h",
       column_right = "l",
       card_up      = "k",
       card_down    = "j",
       move_card    = "m",
+      open_actions = "<CR>",
+      goto_current = "g",
       close        = "q",
       refresh      = "r",
       help         = "?",
@@ -104,8 +133,182 @@ Pass options to `setup()`: >lua
       enabled = true,
       max_budget_usd = 5.00,
       max_turns = 30,
+      allowed_tools = {
+        "Bash(git:*)",
+        "Bash(gh:*)",
+        "Read",
+        "Edit",
+        "Write",
+        "Glob",
+        "Grep",
+      },
+      worktree_base_dir = nil,
+      auto_push = false,
+      auto_pr = false,
     },
   })
 <
+
+Options ~
+
+columns                                             *okuban-config-columns*
+  Type: `table[]`
+  Default: 5 columns (Backlog, Todo, In Progress, Review, Done)
+
+  Each column has:
+  - `label` (string): The GitHub label that maps issues to this column.
+  - `name` (string): Display name shown in the column header.
+  - `color` (string): Hex color for `:OkubanSetup` label creation.
+  - `state` (string|nil): Issue state filter — "open" (default), "closed",
+    or "all". The Done column uses "all" to include closed issues.
+  - `limit` (integer|nil): Max issues to fetch. Default 100.
+
+show_unsorted                                   *okuban-config-show-unsorted*
+  Type: `boolean`, Default: `true`
+  Show a column for issues that have no `okuban:` label.
+
+skip_preflight                                 *okuban-config-skip-preflight*
+  Type: `boolean`, Default: `false`
+  Skip `gh` authentication and scope checks on board open.
+
+github_hostname                               *okuban-config-github-hostname*
+  Type: `string|nil`, Default: `nil`
+  Set to your GitHub Enterprise Server hostname (e.g. "github.mycompany.com").
+
+preview_lines                                   *okuban-config-preview-lines*
+  Type: `integer`, Default: `8`
+  Height of the preview pane below the board. Set to 0 to disable.
+
+show_tldr                                           *okuban-config-show-tldr*
+  Type: `boolean`, Default: `true`
+  Show a TLDR excerpt from the issue body in the preview pane.
+
+poll_interval                                   *okuban-config-poll-interval*
+  Type: `integer`, Default: `20`
+  Auto-refresh interval in seconds. Set to 0 to disable auto-polling.
+
+keymaps                                             *okuban-config-keymaps*
+  Type: `table`
+  Remap any board keybinding. See |okuban-keybindings| for the full list.
+
+claude                                               *okuban-config-claude*
+  Type: `table`
+  Claude Code integration settings.
+  - `enabled` (boolean): Enable the Code action. Default: true.
+  - `max_budget_usd` (number): Spending cap per session. Default: 5.00.
+  - `max_turns` (integer): Max API turns per session. Default: 30.
+  - `allowed_tools` (string[]): Tools the Claude session can use.
+  - `worktree_base_dir` (string|nil): Base directory for worktrees.
+    Default: nil (auto — `../repo-worktrees/`).
+  - `auto_push` (boolean): Push branch on completion. Default: false.
+  - `auto_pr` (boolean): Create PR on completion. Default: false.
+
+==============================================================================
+7. FEATURES                                                 *okuban-features*
+
+Preview Pane ~
+                                                       *okuban-preview-pane*
+A detail pane below the board shows information about the selected card:
+issue number, title, state, labels, assignees, and a body excerpt. Updates
+automatically as you navigate. Configure height with `preview_lines` or
+disable with `preview_lines = 0`.
+
+Auto-Polling ~
+                                                       *okuban-auto-polling*
+The board refreshes from GitHub at a configurable interval (default: 20
+seconds). Disable with `poll_interval = 0`. The refresh preserves your
+current cursor position.
+
+Auto-Focus ~
+                                                        *okuban-auto-focus*
+On board open, okuban detects your current issue using a three-tier cascade:
+
+1. Branch name — patterns like `feat/issue-42-desc`, `fix/123-null`,
+   `GH-42-oauth`, or `42-add-login`.
+2. Recent commits — scans the last 5 commit messages for `#N` references,
+   picks the most-referenced issue.
+3. gh CLI — queries for issues assigned to you with the
+   `okuban:in-progress` label.
+
+Press `g` at any time to re-run detection and jump to the matched card.
+
+Worktree Status ~
+                                                     *okuban-worktree-status*
+Cards show git worktree indicators when a linked worktree exists:
+- `○` — worktree exists, working tree is clean
+- `●` — worktree exists, working tree has uncommitted changes
+- Orange highlight (OkubanCardActive) — your currently active worktree
+
+Claude Code Integration ~
+                                                            *okuban-claude*
+From the action menu, select "Code with Claude" (`x`) to launch an
+autonomous coding session. Okuban will:
+1. Create a git worktree for the issue
+2. Fetch the issue context (title, body, labels, comments)
+3. Launch Claude Code with sandboxed tools and a budget cap
+
+Session status is shown as badges on cards:
+- `[▶]` — session is running
+- `[✓]` — session completed successfully
+- `[✗]` — session failed
+
+Session details appear in the preview pane when a card with an active
+session is selected.
+
+==============================================================================
+8. FAQ                                                           *okuban-faq*
+
+Q: Do I need GitHub Projects? ~
+A: No. okuban.nvim uses GitHub issue labels as its data source. You only
+need issues and labels.
+
+Q: Can I customize the columns? ~
+A: Yes. Pass a `columns` table to `setup()` with your own labels, names,
+and colors. See |okuban-configuration|.
+
+Q: How does auto-focus work? ~
+A: It uses a three-tier detection cascade: branch name, commit messages,
+then `gh` CLI. See |okuban-auto-focus|.
+
+Q: What are the worktree badges? ~
+A: `○` = clean worktree, `●` = dirty worktree, orange highlight = active
+worktree. See |okuban-worktree-status|.
+
+Q: How does Claude Code integration work? ~
+A: It creates a git worktree, fetches issue context, and launches Claude
+Code autonomously. See |okuban-claude|.
+
+Q: Can I use this with GitHub Enterprise? ~
+A: Yes. Set `github_hostname` in your config.
+See |okuban-config-github-hostname|.
+
+Q: How do I disable auto-polling? ~
+A: Set `poll_interval = 0`. See |okuban-config-poll-interval|.
+
+Q: Why is the Done column limited to 20 issues? ~
+A: The Done column includes closed issues, which can grow large. The limit
+keeps the board responsive. Change it via the `limit` field on the column.
+See |okuban-config-columns|.
+
+==============================================================================
+9. TROUBLESHOOTING                                   *okuban-troubleshooting*
+
+"gh CLI not found" ~
+  Install from https://cli.github.com, then run `gh auth login`.
+
+"Not authenticated with GitHub" ~
+  Run `gh auth login` and follow the prompts.
+
+"Labels not showing up" ~
+  Run `:OkubanSetup` to create the default labels, then assign them to
+  your issues.
+
+"Claude Code not available" ~
+  Install Claude Code from https://claude.ai/code. This is optional — the
+  board works fully without it.
+
+"Board looks wrong after resizing" ~
+  The board repositions on VimResized, but if something looks off, press
+  `r` to refresh or reopen with `:Okuban`.
 
  vim:tw=78:ft=help:norl:


### PR DESCRIPTION
## Summary

- **README.md**: Major rewrite — updated status from "Early Development" to "Beta", fixed all roadmap checkboxes to reflect shipped features (Phase 1-3 complete), added complete configuration section with all options and defaults, fixed action menu keys to match actual implementation (m/v/c/a/x not a/b/c), added Features section documenting preview pane/auto-polling/auto-focus/worktree badges/Claude integration, added FAQ section with 8 common questions
- **doc/okuban.txt**: Full vimdoc overhaul with 9 sections — every config option documented with type, default, and description; board and action menu keybindings in separate tables; features section with help tags for each feature; FAQ and troubleshooting sections
- **CONTRIBUTING.md**: New file — prerequisites, dev setup, Makefile targets, code style rules, testing guide with test file index, PR process, architecture overview with data flow explanation
- **GitHub templates**: Bug report template (with environment section), feature request template, PR template with checklist

## Test plan

- [x] `make check` passes (228 tests, 0 warnings)
- [x] `helptags doc/` generates all 29 help tags correctly
- [x] All doc links resolve (label-setup.md, feature-architecture.md, claude-code-workflow.md, CONTRIBUTING.md)
- [x] Config block in README matches actual `lua/okuban/config.lua` defaults
- [x] Action menu keys match actual `lua/okuban/ui/actions.lua` implementation
- [x] Roadmap checkboxes reflect shipped features

Fixes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)