### PR TITLE
chore: clean up Phase 4 roadmap and document highlight groups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,11 +483,8 @@ This plugin targets the Neovim open-source community. All documentation must be 
 3. Monitor running Claude sessions with live status
 
 ### Phase 4: Polish & Community
-1. Telescope integration for repo picker
-2. Customizable colors/highlights
-3. Status line integration
-4. GitHub Actions CI (tests, StyLua, Luacheck)
-5. Issue templates, PR template, labels
+1. GitHub Actions CI (tests, StyLua, Luacheck)
+2. Issue templates, PR template, labels
 
 ### Phase 5: GitHub Projects v2 (v1.0)
 1. GitHub Projects v2 as alternative/additional data source (GraphQL API)

--- a/README.md
+++ b/README.md
@@ -157,6 +157,22 @@ require("okuban").setup({
 
 The Done column uses `state = "all"` to include closed issues and `limit = 20` to cap how many are fetched (for performance). Both are configurable per column.
 
+### Highlight Groups
+
+All highlight groups use `default = true`, so you can override them in your config:
+
+| Group | Default Link | Used For |
+|-------|-------------|----------|
+| `OkubanCardFocused` | `CursorLine` | Currently selected card |
+| `OkubanColumnHeader` | `Title` | Column header text |
+| `OkubanCardActive` | `WarningMsg` | Card with an active git worktree (orange) |
+
+Example override:
+```lua
+vim.api.nvim_set_hl(0, "OkubanCardFocused", { bg = "#2d3f76" })
+vim.api.nvim_set_hl(0, "OkubanCardActive", { fg = "#ff9e64", bold = true })
+```
+
 ## Commands
 
 | Command | Description |
@@ -225,9 +241,6 @@ See [docs/label-setup.md](docs/label-setup.md) for the full label reference with
 - [x] Monitor running Claude sessions with live status badges
 
 ### Phase 4: Polish & Community
-- [ ] Telescope integration for repo picker
-- [ ] Customizable colors and highlight groups
-- [ ] Status line integration
 - [x] GitHub Actions CI (tests, StyLua, Luacheck)
 - [x] Issue templates, PR template, CONTRIBUTING.md
 

--- a/doc/okuban.txt
+++ b/doc/okuban.txt
@@ -203,6 +203,21 @@ claude                                               *okuban-config-claude*
   - `auto_push` (boolean): Push branch on completion. Default: false.
   - `auto_pr` (boolean): Create PR on completion. Default: false.
 
+Highlight Groups ~
+                                                    *okuban-highlight-groups*
+All highlight groups use `default = true`, so you can override them in
+your config:
+
+  Group                 Default Link    Used For ~
+  OkubanCardFocused     CursorLine      Currently selected card
+  OkubanColumnHeader    Title           Column header text
+  OkubanCardActive      WarningMsg      Card with an active worktree
+
+Example: >lua
+  vim.api.nvim_set_hl(0, "OkubanCardFocused", { bg = "#2d3f76" })
+  vim.api.nvim_set_hl(0, "OkubanCardActive", { fg = "#ff9e64", bold = true })
+<
+
 ==============================================================================
 7. FEATURES                                                 *okuban-features*
 


### PR DESCRIPTION
## Summary

- Remove Telescope integration, customizable colors, and status line from Phase 4 roadmap
- Add highlight group documentation to README and vimdoc — `OkubanCardFocused`, `OkubanColumnHeader`, `OkubanCardActive` are already customizable via `vim.api.nvim_set_hl()` (they use `default = true`)
- Update CLAUDE.md Phase 4 to match

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)