### PR TITLE
fix(ui): add Esc keymap and popup cleanup on board close

### DIFF
--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -399,12 +399,18 @@ function Board:open_loading()
   -- Create preview window
   self:_create_preview_window(layout)
 
-  -- Set up q keymap on loading buffers
+  -- Set up close keymaps on loading buffers
   local keymaps = cfg.keymaps
   for _, buf in ipairs(self.buffers) do
+    local buf_opts = { buffer = buf, nowait = true, silent = true }
     vim.keymap.set("n", keymaps.close, function()
       self:close()
-    end, { buffer = buf, nowait = true, silent = true })
+    end, buf_opts)
+    if keymaps.close ~= "<Esc>" then
+      vim.keymap.set("n", "<Esc>", function()
+        self:close()
+      end, buf_opts)
+    end
   end
 
   self:_setup_autocommands()
@@ -647,6 +653,10 @@ function Board:close()
     vim.api.nvim_del_augroup_by_id(self.augroup)
     self.augroup = nil
   end
+
+  -- Close any open popup windows (action menu, help)
+  require("okuban.ui.actions").close()
+  require("okuban.ui.help").close()
 
   -- Close preview window
   if self.preview_win and vim.api.nvim_win_is_valid(self.preview_win) then

--- a/lua/okuban/ui/navigation.lua
+++ b/lua/okuban/ui/navigation.lua
@@ -210,6 +210,13 @@ function Navigation:setup_keymaps(buf)
     self.board:close()
   end, opts)
 
+  -- Always map <Esc> as an additional close key (unless it IS the close key)
+  if keymaps.close ~= "<Esc>" then
+    vim.keymap.set("n", "<Esc>", function()
+      self.board:close()
+    end, opts)
+  end
+
   vim.keymap.set("n", keymaps.refresh, function()
     local api = require("okuban.api")
     api.fetch_all_columns(function(data)


### PR DESCRIPTION
## Summary
- Map `<Esc>` as an additional close key on all board column buffers so users can dismiss the overlay naturally
- `Board:close()` now explicitly cleans up action menu and help popup windows
- Guard against double-mapping when user sets `close = "<Esc>"` in config

Fixes #47

## Test plan
- [x] `make check` passes (317 tests, lint clean)
- [x] `<Esc>` on any board column closes the entire overlay
- [x] `q` still works as before
- [x] Closing board while action menu is open cleans up the menu
- [x] Closing board while help window is open cleans up help

🤖 Generated with [Claude Code](https://claude.com/claude-code)