### PR TITLE
feat: session-level board data cache for instant reopen

### DIFF
--- a/lua/okuban/api.lua
+++ b/lua/okuban/api.lua
@@ -146,6 +146,16 @@ function M.edit_labels(number, remove_label, add_label, callback)
   return require("okuban.api_labels").edit_labels(number, remove_label, add_label, callback)
 end
 
+--- Return cached board data if fresh enough. Routes based on config.source.
+---@param max_age integer Maximum cache age in seconds
+---@return table|nil board_data
+function M.get_cached_board_data(max_age)
+  if config.get().source == "project" then
+    return require("okuban.api_project").get_cached_board_data(max_age)
+  end
+  return require("okuban.api_labels").get_cached_board_data(max_age)
+end
+
 --- Fetch all columns and return structured board data.
 --- Routes to api_labels or api_project based on config.source.
 ---@param callback fun(data: table|nil)

--- a/lua/okuban/api_labels.lua
+++ b/lua/okuban/api_labels.lua
@@ -2,6 +2,10 @@ local utils = require("okuban.utils")
 
 local M = {}
 
+--- Session-level board data cache (survives board close/reopen).
+local board_cache = nil ---@type table|nil
+local board_cache_ts = 0 ---@type integer
+
 --- Get the gh base command from the shared api module.
 ---@return string[]
 local function gh_base_cmd()
@@ -158,6 +162,8 @@ function M.fetch_all_columns(callback)
       if cfg.show_unsorted then
         board_data.unsorted = results["_unsorted"] or {}
       end
+      board_cache = board_data
+      board_cache_ts = os.time()
       callback(board_data)
     end
   end
@@ -260,6 +266,16 @@ function M.create_all_labels(full, callback)
       end
     end)
   end
+end
+
+--- Return cached board data if it exists and is younger than max_age seconds.
+---@param max_age integer Maximum cache age in seconds
+---@return table|nil board_data
+function M.get_cached_board_data(max_age)
+  if board_cache and (os.time() - board_cache_ts) < max_age then
+    return board_cache
+  end
+  return nil
 end
 
 return M

--- a/lua/okuban/api_project.lua
+++ b/lua/okuban/api_project.lua
@@ -8,6 +8,8 @@ local cache = {
   column_field_name = nil, -- name of the field used for board columns (e.g. "Status", "Workflow Stage")
   status_field = nil, -- { id, options = [{ id, name }] }, fetched once
   item_map = {}, -- issue_number → item_node_id, rebuilt each fetch
+  board_data = nil, -- last fetched board data, survives board close/reopen
+  board_data_ts = 0, -- os.time() when board_data was last stored
 }
 
 --- Get the gh base command from the shared api module.
@@ -459,6 +461,8 @@ function M.fetch_all_columns(callback)
             return
           end
           local board_data = M.build_board_data(items, status_field, show_unsorted, proj.done_limit or 20)
+          cache.board_data = board_data
+          cache.board_data_ts = os.time()
           callback(board_data)
         end)
       end
@@ -611,12 +615,24 @@ function M.get_cached_column_field_name()
   return cache.column_field_name
 end
 
+--- Return cached board data if it exists and is younger than max_age seconds.
+---@param max_age integer Maximum cache age in seconds
+---@return table|nil board_data
+function M.get_cached_board_data(max_age)
+  if cache.board_data and (os.time() - cache.board_data_ts) < max_age then
+    return cache.board_data
+  end
+  return nil
+end
+
 --- Reset all caches (for testing and source switching).
 function M.reset_cache()
   cache.project_id = nil
   cache.column_field_name = nil
   cache.status_field = nil
   cache.item_map = {}
+  cache.board_data = nil
+  cache.board_data_ts = 0
 end
 
 --- Set cache values directly (for testing).

--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -111,33 +111,32 @@ function M.open()
   end)
 end
 
---- Fetch data and populate an already-opened loading board.
----@param board table Board instance (already showing loading skeleton)
-function M._open_board(board)
-  api.fetch_all_columns(function(data)
-    if not data then
-      utils.notify("Failed to fetch issues", vim.log.levels.ERROR)
-      board:close()
-      return
-    end
-    board:populate(data)
+local CACHE_MAX_AGE = 3600 -- 1 hour
 
-    -- First-open hint: if all kanban columns empty but unsorted has issues
-    if not board._hint_shown then
-      board._hint_shown = true
-      local all_empty = true
-      for _, col in ipairs(data.columns) do
-        if #col.issues > 0 then
-          all_empty = false
-          break
-        end
-      end
-      if all_empty and data.unsorted and #data.unsorted > 0 then
-        utils.notify("Tip: press Enter on a card to triage it into a column, or m to move it directly")
+--- Populate board with data and run first-open checks.
+---@param board table Board instance
+---@param data table Board data from api.fetch_all_columns
+---@param skip_focus boolean If true, skip auto-focus (used for cached data)
+function M._populate_board(board, data, skip_focus)
+  board:populate(data)
+
+  -- First-open hint: if all kanban columns empty but unsorted has issues
+  if not board._hint_shown then
+    board._hint_shown = true
+    local all_empty = true
+    for _, col in ipairs(data.columns) do
+      if #col.issues > 0 then
+        all_empty = false
+        break
       end
     end
+    if all_empty and data.unsorted and #data.unsorted > 0 then
+      utils.notify("Tip: press Enter on a card to triage it into a column, or m to move it directly")
+    end
+  end
 
-    -- Auto-focus: detect current issue and navigate to it
+  -- Auto-focus: detect current issue and navigate to it
+  if not skip_focus then
     local detect = require("okuban.detect")
     detect.detect_issue(function(issue_number)
       if not issue_number or not board:is_open() or not board.navigation then
@@ -150,6 +149,34 @@ function M._open_board(board)
         utils.notify("Focused on #" .. issue_number .. ": " .. title)
       end
     end)
+  end
+end
+
+--- Fetch data and populate an already-opened loading board.
+--- If cached data is available (< 1h old), shows it instantly and refreshes in background.
+---@param board table Board instance (already showing loading skeleton)
+function M._open_board(board)
+  -- Try cached data first for instant display
+  local cached = api.get_cached_board_data(CACHE_MAX_AGE)
+  if cached then
+    M._populate_board(board, cached, false)
+    -- Refresh in background
+    api.fetch_all_columns(function(data)
+      if data and board:is_open() then
+        board:refresh(data)
+      end
+    end)
+    return
+  end
+
+  -- No cache — fetch fresh (loading skeleton already visible)
+  api.fetch_all_columns(function(data)
+    if not data then
+      utils.notify("Failed to fetch issues", vim.log.levels.ERROR)
+      board:close()
+      return
+    end
+    M._populate_board(board, data, false)
   end)
 end
 


### PR DESCRIPTION
## Summary
- Cache last fetched board data in module-level Lua variables (survives board close/reopen, no filesystem writes)
- On board reopen, if cache is < 1 hour old, show cached data instantly and refresh in background
- Works for both label and project data sources
- Background refresh keeps data fresh; auto-polling (every 20s) handles ongoing updates

Fixes #49

## Test plan
- [x] `make check` passes (317 tests, lint clean)
- [x] First `:Okuban` shows loading skeleton → fetches → populates (unchanged behavior)
- [x] Close board with `q`, reopen with `:Okuban` → board appears instantly with cached data
- [x] Background refresh updates board silently after cache display
- [x] After 1 hour of inactivity, cache expires and loading skeleton is shown again
- [x] Source switch (`OkubanSource`) clears project cache correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)