### PR TITLE
feat(ui): dynamic header menu bar with issue mode

### DIFF
--- a/lua/okuban/ui/actions.lua
+++ b/lua/okuban/ui/actions.lua
@@ -134,6 +134,23 @@ function M._build_actions(issue, board)
   return actions
 end
 
+--- Execute a specific action by key for the given issue.
+--- Used by navigation keymaps in issue mode (replaces popup interaction).
+---@param key string Action key (m, v, c, a, x)
+---@param issue table Issue data
+---@param board table Board instance
+---@return boolean executed True if action was found and executed
+function M.execute_action(key, issue, board)
+  local action_list = M._build_actions(issue, board)
+  for _, action in ipairs(action_list) do
+    if action.key == key then
+      action.callback()
+      return true
+    end
+  end
+  return false
+end
+
 --- Open the action menu for the currently selected card.
 ---@param board table Board instance
 function M.open(board)

--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -1,6 +1,7 @@
 local card = require("okuban.ui.card")
 local claude = require("okuban.claude")
 local config = require("okuban.config")
+local header = require("okuban.ui.header")
 local utils = require("okuban.utils")
 local worktree = require("okuban.worktree")
 
@@ -20,6 +21,7 @@ end
 local ns_active = vim.api.nvim_create_namespace("okuban_worktree_active")
 
 --- Calculate layout dimensions for the board.
+--- Includes space for a 1-line header bar above the columns.
 ---@param num_cols integer
 ---@param screen_width integer|nil
 ---@param screen_height integer|nil
@@ -43,18 +45,26 @@ function Board.calculate_layout(num_cols, screen_width, screen_height, preview_l
 
   local total_height = math.floor(sh * 0.8)
 
+  -- Header: 1 line content + 2 border + 1 gap below = 4 rows
+  local header_inner = 1
+  local header_border = 2
+  local header_gap = 1
+  local header_space = header_inner + header_border + header_gap
+
   if preview_lines > 0 then
     -- Columns get 75% of available height, preview gets the rest
-    local available = total_height - 3 -- 3 = 2 (preview border) + 1 (gap)
+    local available = total_height - header_space - 3 -- 3 = 2 (preview border) + 1 (gap)
     local board_height = math.floor(available * 0.75)
     if board_height < 5 then
       board_height = 5
     end
     local effective_preview = available - board_height
 
-    -- Center the total visual block: columns + gap + preview (each with border)
-    local total_visual = board_height + 2 + 1 + effective_preview + 2
-    local start_row = math.floor((sh - total_visual) / 2)
+    -- Center the total visual block: header + gap + columns + gap + preview
+    local total_visual = (header_inner + header_border) + header_gap + board_height + 2 + 1 + effective_preview + 2
+    local block_start = math.floor((sh - total_visual) / 2)
+    local header_row = block_start
+    local start_row = block_start + header_space
     local start_col = math.floor((sw - board_width) / 2)
     local preview_row = start_row + board_height + 2 + 1
 
@@ -65,12 +75,19 @@ function Board.calculate_layout(num_cols, screen_width, screen_height, preview_l
       start_row = start_row,
       start_col = start_col,
       gap = gap,
+      header_row = header_row,
+      header_height = header_inner,
       preview_height = effective_preview,
       preview_row = preview_row,
     }
   else
-    local board_height = total_height
-    local start_row = math.floor((sh - board_height) / 2)
+    local board_height = total_height - header_space
+
+    -- Center the total visual block: header + gap + columns
+    local total_visual = (header_inner + header_border) + header_gap + board_height + 2
+    local block_start = math.floor((sh - total_visual) / 2)
+    local header_row = block_start
+    local start_row = block_start + header_space
     local start_col = math.floor((sw - board_width) / 2)
 
     return {
@@ -80,6 +97,8 @@ function Board.calculate_layout(num_cols, screen_width, screen_height, preview_l
       start_row = start_row,
       start_col = start_col,
       gap = gap,
+      header_row = header_row,
+      header_height = header_inner,
     }
   end
 end
@@ -313,6 +332,13 @@ function Board:_setup_autocommands()
     group = self.augroup,
     callback = function(ev)
       local closed_win = tonumber(ev.match)
+      local hwin = header.get_win()
+      if hwin and hwin == closed_win then
+        vim.schedule(function()
+          self:close()
+        end)
+        return
+      end
       if self.preview_win and self.preview_win == closed_win then
         vim.schedule(function()
           self:close()
@@ -348,6 +374,9 @@ function Board:open_loading()
   local preview_lines = cfg.preview_lines or 0
   local layout = Board.calculate_layout(num_cols, nil, nil, preview_lines)
   self.augroup = vim.api.nvim_create_augroup("OkubanBoard", { clear = true })
+
+  -- Create header bar above columns
+  header.create(layout)
 
   -- Build placeholder column names
   local col_names = {}
@@ -510,10 +539,12 @@ function Board:populate(data)
   if self.navigation then
     local old_col = self.navigation.column_index
     local old_card = self.navigation.card_index
+    local old_issue_mode = self.navigation.issue_mode
     self.navigation = Navigation.new(self)
     self.navigation.column_index = math.min(old_col, self.navigation:num_columns())
     local count = self.navigation:card_count(self.navigation.column_index)
     self.navigation.card_index = math.min(old_card, math.max(1, count))
+    self.navigation.issue_mode = old_issue_mode or false
   else
     self.navigation = Navigation.new(self)
   end
@@ -542,6 +573,9 @@ function Board:open(data)
   local preview_lines = cfg.preview_lines or 0
   local layout = Board.calculate_layout(#cols, nil, nil, preview_lines)
   self.augroup = vim.api.nvim_create_augroup("OkubanBoard", { clear = true })
+
+  -- Create header bar above columns
+  header.create(layout)
 
   -- Fetch worktree map for card badges
   local wt_map = worktree.fetch_worktree_map()
@@ -633,6 +667,9 @@ function Board:_reposition()
     end
   end
 
+  -- Reposition header window
+  header.reposition(layout)
+
   -- Reposition preview window
   if self.preview_win and vim.api.nvim_win_is_valid(self.preview_win) and layout.preview_row then
     vim.api.nvim_win_set_config(self.preview_win, {
@@ -654,9 +691,10 @@ function Board:close()
     self.augroup = nil
   end
 
-  -- Close any open popup windows (action menu, help)
+  -- Close any open popup windows (action menu, help) and header
   require("okuban.ui.actions").close()
   require("okuban.ui.help").close()
+  header.close()
 
   -- Close preview window
   if self.preview_win and vim.api.nvim_win_is_valid(self.preview_win) then

--- a/lua/okuban/ui/header.lua
+++ b/lua/okuban/ui/header.lua
@@ -1,0 +1,173 @@
+local config = require("okuban.config")
+
+local M = {}
+
+M.MODE_DEFAULT = "default"
+M.MODE_ISSUE = "issue"
+
+local header_win = nil
+local header_buf = nil
+local current_mode = M.MODE_DEFAULT
+local current_issue = nil
+local stored_width = nil
+
+--- Render header content lines based on mode.
+---@param mode string
+---@param issue table|nil
+---@return string[]
+function M._render(mode, issue)
+  local width = stored_width or 100
+
+  if mode == M.MODE_ISSUE and issue then
+    local parts = { " [Esc] Back  [m] Move  [v] View" }
+    local is_open = issue.state ~= "CLOSED"
+    if is_open then
+      table.insert(parts, "  [c] Close  [a] Assign")
+    end
+    local claude_cfg = config.get().claude
+    if claude_cfg.enabled then
+      local ok, claude_mod = pcall(require, "okuban.claude")
+      if ok and claude_mod.is_available() then
+        table.insert(parts, "  [x] Code")
+      end
+    end
+    local prefix = table.concat(parts, "")
+    local separator = "  │  "
+    local title = string.format("#%d: %s", issue.number, issue.title or "Untitled")
+    local title_space = width - #prefix - #separator - 2
+    if title_space > 0 and #title > title_space then
+      title = title:sub(1, title_space - 3) .. "..."
+    end
+    return { prefix .. separator .. title }
+  else
+    return { " [Enter] Actions  [m] Move  [g] Goto  [r] Refresh  [?] Help  [q] Close" }
+  end
+end
+
+--- Create the header floating window.
+---@param layout table Layout from Board.calculate_layout
+function M.create(layout)
+  if header_win and vim.api.nvim_win_is_valid(header_win) then
+    return
+  end
+
+  stored_width = layout.board_width
+
+  header_buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[header_buf].buftype = "nofile"
+  vim.bo[header_buf].bufhidden = "wipe"
+  vim.bo[header_buf].swapfile = false
+  vim.bo[header_buf].filetype = "okuban"
+
+  local lines = M._render(M.MODE_DEFAULT, nil)
+  vim.api.nvim_buf_set_lines(header_buf, 0, -1, false, lines)
+  vim.bo[header_buf].modifiable = false
+
+  header_win = vim.api.nvim_open_win(header_buf, false, {
+    relative = "editor",
+    row = layout.header_row,
+    col = layout.start_col,
+    width = layout.board_width,
+    height = layout.header_height,
+    style = "minimal",
+    border = "rounded",
+    title = " okuban ",
+    title_pos = "center",
+    focusable = false,
+    zindex = 50,
+  })
+
+  vim.wo[header_win].cursorline = false
+  vim.wo[header_win].wrap = false
+  vim.wo[header_win].number = false
+  vim.wo[header_win].relativenumber = false
+  vim.wo[header_win].signcolumn = "no"
+
+  current_mode = M.MODE_DEFAULT
+  current_issue = nil
+end
+
+--- Update header content for the given mode and issue.
+---@param mode string
+---@param issue table|nil
+function M.update(mode, issue)
+  if not header_buf or not vim.api.nvim_buf_is_valid(header_buf) then
+    return
+  end
+  current_mode = mode
+  current_issue = issue
+  local lines = M._render(mode, issue)
+  vim.bo[header_buf].modifiable = true
+  vim.api.nvim_buf_set_lines(header_buf, 0, -1, false, lines)
+  vim.bo[header_buf].modifiable = false
+end
+
+--- Get the current header mode.
+---@return string
+function M.get_mode()
+  return current_mode
+end
+
+--- Check if header is in issue mode.
+---@return boolean
+function M.is_issue_mode()
+  return current_mode == M.MODE_ISSUE
+end
+
+--- Enter issue mode for the given issue.
+---@param issue table
+function M.enter_issue_mode(issue)
+  M.update(M.MODE_ISSUE, issue)
+end
+
+--- Exit issue mode back to default.
+function M.exit_issue_mode()
+  M.update(M.MODE_DEFAULT, nil)
+end
+
+--- Close the header window and clean up.
+function M.close()
+  if header_win and vim.api.nvim_win_is_valid(header_win) then
+    vim.api.nvim_win_close(header_win, true)
+  end
+  header_win = nil
+  header_buf = nil
+  current_mode = M.MODE_DEFAULT
+  current_issue = nil
+  stored_width = nil
+end
+
+--- Reposition the header window after a resize.
+---@param layout table Layout from Board.calculate_layout
+function M.reposition(layout)
+  if not header_win or not vim.api.nvim_win_is_valid(header_win) then
+    return
+  end
+  stored_width = layout.board_width
+  vim.api.nvim_win_set_config(header_win, {
+    relative = "editor",
+    row = layout.header_row,
+    col = layout.start_col,
+    width = layout.board_width,
+    height = layout.header_height,
+  })
+  -- Re-render to fit new width
+  M.update(current_mode, current_issue)
+end
+
+--- Get the header window handle (for autocommand checks).
+---@return integer|nil
+function M.get_win()
+  return header_win
+end
+
+--- Reset state (for tests).
+function M._reset()
+  header_win = nil
+  header_buf = nil
+  current_mode = M.MODE_DEFAULT
+  current_issue = nil
+  stored_width = nil
+end
+
+return M

--- a/lua/okuban/ui/navigation.lua
+++ b/lua/okuban/ui/navigation.lua
@@ -13,6 +13,7 @@ function Navigation.new(board)
   o.board = board
   o.column_index = 1
   o.card_index = 1
+  o.issue_mode = false
   return o
 end
 
@@ -138,8 +139,15 @@ function Navigation:highlight_current()
   end
 
   -- Update preview pane with selected issue
+  local issue = self:get_selected_issue()
   if self.board.update_preview then
-    self.board:update_preview(self:get_selected_issue())
+    self.board:update_preview(issue)
+  end
+
+  -- Update header when in issue mode
+  if self.issue_mode and issue then
+    local header = require("okuban.ui.header")
+    header.enter_issue_mode(issue)
   end
 end
 
@@ -160,6 +168,25 @@ function Navigation:focus_issue(issue_number)
     end
   end
   return false
+end
+
+--- Toggle issue mode on/off.
+--- In issue mode, the header shows issue-specific actions (view, close, assign, code).
+function Navigation:toggle_issue_mode()
+  local hdr = require("okuban.ui.header")
+  if self.issue_mode then
+    self.issue_mode = false
+    hdr.exit_issue_mode()
+  else
+    local issue = self:get_selected_issue()
+    if not issue then
+      local utils = require("okuban.utils")
+      utils.notify("No issue selected", vim.log.levels.WARN)
+      return
+    end
+    self.issue_mode = true
+    hdr.enter_issue_mode(issue)
+  end
 end
 
 --- Get the issue data for the currently selected card.
@@ -210,10 +237,14 @@ function Navigation:setup_keymaps(buf)
     self.board:close()
   end, opts)
 
-  -- Always map <Esc> as an additional close key (unless it IS the close key)
+  -- Esc: exit issue mode first, then close board
   if keymaps.close ~= "<Esc>" then
     vim.keymap.set("n", "<Esc>", function()
-      self.board:close()
+      if self.issue_mode then
+        self:toggle_issue_mode()
+      else
+        self.board:close()
+      end
     end, opts)
   end
 
@@ -231,10 +262,26 @@ function Navigation:setup_keymaps(buf)
     move.prompt_move(self.board)
   end, opts)
 
+  -- Enter: toggle issue mode (replaces action menu popup)
   vim.keymap.set("n", keymaps.open_actions, function()
-    local actions = require("okuban.ui.actions")
-    actions.open(self.board)
+    self:toggle_issue_mode()
   end, opts)
+
+  -- Issue-mode action keymaps (v, c, a, x)
+  local action_keys = { "v", "c", "a", "x" }
+  for _, key in ipairs(action_keys) do
+    vim.keymap.set("n", key, function()
+      if not self.issue_mode then
+        return
+      end
+      local issue = self:get_selected_issue()
+      if not issue then
+        return
+      end
+      local actions = require("okuban.ui.actions")
+      actions.execute_action(key, issue, self.board)
+    end, opts)
+  end
 
   vim.keymap.set("n", keymaps.help, function()
     local help = require("okuban.ui.help")

--- a/tests/test_actions_spec.lua
+++ b/tests/test_actions_spec.lua
@@ -159,6 +159,35 @@ describe("okuban.ui.actions", function()
     end)
   end)
 
+  describe("execute_action", function()
+    it("finds move action for open issue", function()
+      local issue = { number = 42, title = "Test", state = "OPEN" }
+      local board = {}
+      local action_list = actions._build_actions(issue, board)
+      local found = false
+      for _, a in ipairs(action_list) do
+        if a.key == "m" then
+          found = true
+        end
+      end
+      assert.is_true(found)
+    end)
+
+    it("returns false for unknown key", function()
+      local issue = { number = 42, title = "Test", state = "OPEN" }
+      local board = {}
+      local result = actions.execute_action("z", issue, board)
+      assert.is_false(result)
+    end)
+
+    it("returns false for closed-issue-only actions on closed issues", function()
+      local issue = { number = 42, title = "Test", state = "CLOSED" }
+      local board = {}
+      local result = actions.execute_action("c", issue, board)
+      assert.is_false(result)
+    end)
+  end)
+
   describe("open_actions keymap", function()
     it("is configured as Enter by default", function()
       local keymaps = config.get().keymaps

--- a/tests/test_board_layout_spec.lua
+++ b/tests/test_board_layout_spec.lua
@@ -12,7 +12,8 @@ describe("okuban.ui.board layout", function()
     it("calculates correct dimensions for 5 columns on 120x40 terminal", function()
       local layout = Board.calculate_layout(5, 120, 40)
       assert.equals(108, layout.board_width) -- floor(120 * 0.9)
-      assert.equals(32, layout.board_height) -- floor(40 * 0.8)
+      -- board_height = floor(40*0.8) - 4 (header space) = 28
+      assert.equals(28, layout.board_height)
       -- col_width = floor((108 - 4*1) / 5) = floor(104/5) = 20
       assert.equals(20, layout.col_width)
       assert.equals(1, layout.gap)
@@ -21,7 +22,8 @@ describe("okuban.ui.board layout", function()
     it("calculates correct dimensions for 6 columns on 160x50 terminal", function()
       local layout = Board.calculate_layout(6, 160, 50)
       assert.equals(144, layout.board_width) -- floor(160 * 0.9)
-      assert.equals(40, layout.board_height) -- floor(50 * 0.8)
+      -- board_height = floor(50*0.8) - 4 = 36
+      assert.equals(36, layout.board_height)
       -- col_width = floor((144 - 5*1) / 6) = floor(139/6) = 23
       assert.equals(23, layout.col_width)
     end)
@@ -36,8 +38,10 @@ describe("okuban.ui.board layout", function()
       local layout = Board.calculate_layout(5, 120, 40)
       -- start_col = floor((120 - 108) / 2) = 6
       assert.equals(6, layout.start_col)
-      -- start_row = floor((40 - 32) / 2) = 4
-      assert.equals(4, layout.start_row)
+      -- total_visual = 3 (header) + 1 (gap) + 28 + 2 (border) = 34
+      -- block_start = floor((40 - 34) / 2) = 3
+      -- start_row = block_start + 4 (header space) = 7
+      assert.equals(7, layout.start_row)
     end)
 
     it("works with single column", function()
@@ -56,10 +60,10 @@ describe("okuban.ui.board layout", function()
 
     it("splits available height 75/25 between columns and preview", function()
       local layout = Board.calculate_layout(5, 120, 40, 8)
-      -- available = floor(40*0.8) - 3 = 29
-      -- board = floor(29 * 0.75) = 21, preview = 29 - 21 = 8
-      assert.equals(21, layout.board_height)
-      assert.equals(8, layout.preview_height)
+      -- available = floor(40*0.8) - 4 (header) - 3 (preview border+gap) = 25
+      -- board = floor(25 * 0.75) = 18, preview = 25 - 18 = 7
+      assert.equals(18, layout.board_height)
+      assert.equals(7, layout.preview_height)
       assert.is_not_nil(layout.preview_row)
     end)
 
@@ -83,16 +87,33 @@ describe("okuban.ui.board layout", function()
 
     it("gives preview more space on larger terminals", function()
       local layout = Board.calculate_layout(5, 160, 50, 8)
-      -- available = floor(50*0.8) - 3 = 37
-      -- board = floor(37 * 0.75) = 27, preview = 37 - 27 = 10
-      assert.equals(27, layout.board_height)
-      assert.equals(10, layout.preview_height)
+      -- available = floor(50*0.8) - 4 - 3 = 33
+      -- board = floor(33 * 0.75) = 24, preview = 33 - 24 = 9
+      assert.equals(24, layout.board_height)
+      assert.equals(9, layout.preview_height)
     end)
 
     it("enforces minimum board height with preview", function()
       -- Very small terminal with preview
       local layout = Board.calculate_layout(5, 120, 15, 5)
       assert.is_true(layout.board_height >= 5)
+    end)
+
+    it("includes header_row and header_height in layout", function()
+      local layout = Board.calculate_layout(5, 120, 40)
+      assert.is_not_nil(layout.header_row)
+      assert.equals(1, layout.header_height)
+      -- header_row should be before start_row
+      assert.is_true(layout.header_row < layout.start_row)
+      -- start_row = header_row + 4 (header_inner + border + gap)
+      assert.equals(layout.header_row + 4, layout.start_row)
+    end)
+
+    it("includes header_row in preview layout", function()
+      local layout = Board.calculate_layout(5, 120, 40, 8)
+      assert.is_not_nil(layout.header_row)
+      assert.equals(1, layout.header_height)
+      assert.equals(layout.header_row + 4, layout.start_row)
     end)
   end)
 end)

--- a/tests/test_header_spec.lua
+++ b/tests/test_header_spec.lua
@@ -1,0 +1,124 @@
+describe("okuban.ui.header", function()
+  local header
+
+  before_each(function()
+    package.loaded["okuban.ui.header"] = nil
+    package.loaded["okuban.config"] = nil
+    require("okuban.config")
+    header = require("okuban.ui.header")
+    header._reset()
+  end)
+
+  describe("mode constants", function()
+    it("has default mode", function()
+      assert.equals("default", header.MODE_DEFAULT)
+    end)
+
+    it("has issue mode", function()
+      assert.equals("issue", header.MODE_ISSUE)
+    end)
+  end)
+
+  describe("get_mode", function()
+    it("returns default mode initially", function()
+      assert.equals("default", header.get_mode())
+    end)
+  end)
+
+  describe("is_issue_mode", function()
+    it("returns false initially", function()
+      assert.is_false(header.is_issue_mode())
+    end)
+  end)
+
+  describe("_render default mode", function()
+    it("returns a single line with default keybindings", function()
+      local lines = header._render("default", nil)
+      assert.equals(1, #lines)
+      assert.truthy(lines[1]:find("%[Enter%]"))
+      assert.truthy(lines[1]:find("%[m%]"))
+      assert.truthy(lines[1]:find("%[%?%]"))
+      assert.truthy(lines[1]:find("%[q%]"))
+    end)
+
+    it("includes Help action", function()
+      local lines = header._render("default", nil)
+      assert.truthy(lines[1]:find("Help"))
+    end)
+
+    it("includes Refresh action", function()
+      local lines = header._render("default", nil)
+      assert.truthy(lines[1]:find("Refresh"))
+    end)
+  end)
+
+  describe("_render issue mode", function()
+    local open_issue = { number = 42, title = "Fix login bug", state = "OPEN" }
+    local closed_issue = { number = 99, title = "Old bug", state = "CLOSED" }
+
+    it("returns a single line with issue actions", function()
+      local lines = header._render("issue", open_issue)
+      assert.equals(1, #lines)
+      assert.truthy(lines[1]:find("%[m%]"))
+      assert.truthy(lines[1]:find("%[v%]"))
+      assert.truthy(lines[1]:find("#42"))
+    end)
+
+    it("shows Back action for escaping issue mode", function()
+      local lines = header._render("issue", open_issue)
+      assert.truthy(lines[1]:find("%[Esc%] Back"))
+    end)
+
+    it("includes close and assign for open issues", function()
+      local lines = header._render("issue", open_issue)
+      assert.truthy(lines[1]:find("%[c%] Close"))
+      assert.truthy(lines[1]:find("%[a%] Assign"))
+    end)
+
+    it("excludes close and assign for closed issues", function()
+      local lines = header._render("issue", closed_issue)
+      assert.is_nil(lines[1]:find("%[c%] Close"))
+      assert.is_nil(lines[1]:find("%[a%] Assign"))
+    end)
+
+    it("includes issue number and title", function()
+      local lines = header._render("issue", open_issue)
+      assert.truthy(lines[1]:find("#42: Fix login bug"))
+    end)
+
+    it("truncates long titles", function()
+      local long_issue = { number = 1, title = string.rep("x", 200), state = "OPEN" }
+      local lines = header._render("issue", long_issue)
+      assert.truthy(lines[1]:find("%.%.%."))
+    end)
+
+    it("falls back to default when issue is nil", function()
+      local lines = header._render("issue", nil)
+      assert.truthy(lines[1]:find("%[Enter%]"))
+    end)
+  end)
+
+  describe("enter/exit issue mode", function()
+    it("enters issue mode via update", function()
+      -- Simulate a header buffer (module-level state)
+      -- Without a real buffer, update is a no-op but mode tracking still works
+      -- via enter_issue_mode/exit_issue_mode calling update which checks buffer validity
+      -- For unit tests, we test the render logic directly
+      assert.is_false(header.is_issue_mode())
+    end)
+  end)
+
+  describe("close", function()
+    it("resets mode on close", function()
+      header.close()
+      assert.equals("default", header.get_mode())
+      assert.is_false(header.is_issue_mode())
+    end)
+  end)
+
+  describe("get_win", function()
+    it("returns nil when no header window exists", function()
+      assert.is_nil(header.get_win())
+    end)
+  end)
+end)

--- a/tests/test_navigation_spec.lua
+++ b/tests/test_navigation_spec.lua
@@ -205,6 +205,65 @@ describe("okuban.ui.navigation", function()
     end)
   end)
 
+  describe("issue_mode", function()
+    it("starts with issue_mode false", function()
+      local board = mock_board({ 3, 2 })
+      local nav = Navigation.new(board)
+      assert.is_false(nav.issue_mode)
+    end)
+
+    it("toggles issue_mode on when issue is selected", function()
+      local board = mock_board({ 3, 2 })
+      local nav = Navigation.new(board)
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+
+      -- Stub header module
+      package.loaded["okuban.ui.header"] = {
+        enter_issue_mode = function() end,
+        exit_issue_mode = function() end,
+      }
+
+      nav:toggle_issue_mode()
+      assert.is_true(nav.issue_mode)
+    end)
+
+    it("toggles issue_mode off when already in issue mode", function()
+      local board = mock_board({ 3, 2 })
+      local nav = Navigation.new(board)
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+
+      package.loaded["okuban.ui.header"] = {
+        enter_issue_mode = function() end,
+        exit_issue_mode = function() end,
+      }
+
+      nav.issue_mode = true
+      nav:toggle_issue_mode()
+      assert.is_false(nav.issue_mode)
+    end)
+
+    it("does not enter issue_mode on empty column", function()
+      local board = mock_board({ 0 })
+      local nav = Navigation.new(board)
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+
+      -- Stub utils.notify to suppress output
+      package.loaded["okuban.utils"] = {
+        notify = function() end,
+      }
+      package.loaded["okuban.ui.header"] = {
+        enter_issue_mode = function() end,
+        exit_issue_mode = function() end,
+      }
+
+      nav:toggle_issue_mode()
+      assert.is_false(nav.issue_mode)
+    end)
+  end)
+
   describe("empty columns", function()
     it("handles column with zero issues", function()
       local board = mock_board({ 0, 3, 0 })


### PR DESCRIPTION
## Summary

- Replace floating action popup with a persistent header bar above board columns
- Header shows contextual keybindings that change based on mode (default vs issue)
- Enter toggles "issue mode" on the focused card; Esc exits issue mode first, then closes board
- Action keys (v/c/a/x) execute directly from column buffers in issue mode — no popup needed
- Layout calculation reserves header space (4 rows), shifting columns down

## Details

**New file:** `lua/okuban/ui/header.lua` — singleton header window manager with two modes:
- **Default mode:** `[Enter] Actions  [m] Move  [g] Goto  [r] Refresh  [?] Help  [q] Close`
- **Issue mode:** `[Esc] Back  [m] Move  [v] View  [c] Close  [a] Assign  [x] Code  │  #N: Title`

**Modified files:**
- `board.lua` — layout calculation includes header space, header lifecycle in open/close/reposition
- `navigation.lua` — `issue_mode` state, `toggle_issue_mode()`, action keymaps (v/c/a/x), Esc dual behavior
- `actions.lua` — new `execute_action(key, issue, board)` for direct keymap execution

**Tests:** 17 new header tests, 4 new navigation tests, 3 new action tests. All 285+ tests pass.

Fixes #51

## Test plan

- [x] `make check` passes (lint + 285+ tests, 0 failures)
- [ ] Manual: `:Okuban` → header bar visible above columns with default keybindings
- [ ] Manual: Press Enter on a card → header switches to issue mode showing `#N: Title`
- [ ] Manual: Press Esc in issue mode → back to default mode
- [ ] Manual: Press `v` in issue mode → opens issue in browser
- [ ] Manual: Navigate between cards in issue mode → header updates with new issue
- [ ] Manual: Resize terminal → header repositions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)