### PR TITLE
feat(ui): sub-issue count badges on cards

### DIFF
--- a/lua/okuban/api.lua
+++ b/lua/okuban/api.lua
@@ -126,6 +126,47 @@ function M._reset_preflight()
   preflight_passed = false
 end
 
+-- ---------------------------------------------------------------------------
+-- Repo info detection (cached)
+-- ---------------------------------------------------------------------------
+
+local repo_info_cache = nil ---@type {owner: string, name: string}|nil
+
+--- Detect the repo owner and name (cached).
+---@param callback fun(owner: string|nil, name: string|nil)
+function M.detect_repo_info(callback)
+  if repo_info_cache then
+    callback(repo_info_cache.owner, repo_info_cache.name)
+    return
+  end
+  local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), {
+    "repo",
+    "view",
+    "--json",
+    "owner,name",
+    "-q",
+    '.owner.login + "|" + .name',
+  })
+  vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      if result.code == 0 and result.stdout then
+        local owner, name = vim.trim(result.stdout):match("^(.+)|(.+)$")
+        if owner and name then
+          repo_info_cache = { owner = owner, name = name }
+          callback(owner, name)
+          return
+        end
+      end
+      callback(nil, nil)
+    end)
+  end)
+end
+
+--- Reset repo info cache (for testing).
+function M._reset_repo_info()
+  repo_info_cache = nil
+end
+
 --- Expose gh_base_cmd for other api modules.
 ---@return string[]
 function M._gh_base_cmd()
@@ -174,6 +215,18 @@ function M.expand_column(col_index, callback)
     return require("okuban.api_project").expand_column(col_index, callback)
   end
   return require("okuban.api_labels").expand_column(col_index, callback)
+end
+
+--- Fetch sub-issue counts for a list of issue numbers. Routes based on source.
+--- In project mode, counts are embedded in issue objects (no extra call needed).
+---@param issue_numbers integer[]
+---@param callback fun(counts: table<integer, {total: integer, completed: integer}>)
+function M.fetch_sub_issue_counts(issue_numbers, callback)
+  if config.get().source == "project" then
+    callback({})
+    return
+  end
+  return require("okuban.api_labels").fetch_sub_issue_counts(issue_numbers, callback)
 end
 
 --- Fetch issues for a single label (label-mode only).

--- a/lua/okuban/api_labels.lua
+++ b/lua/okuban/api_labels.lua
@@ -252,6 +252,92 @@ function M.expand_column(col_index, callback)
 end
 
 -- ---------------------------------------------------------------------------
+-- Sub-issue counts
+-- ---------------------------------------------------------------------------
+
+--- Batch-fetch sub-issue counts via GraphQL aliases.
+---@param issue_numbers integer[]
+---@param callback fun(counts: table<integer, {total: integer, completed: integer}>)
+function M.fetch_sub_issue_counts(issue_numbers, callback)
+  if not issue_numbers or #issue_numbers == 0 then
+    callback({})
+    return
+  end
+
+  local api = require("okuban.api")
+  api.detect_repo_info(function(owner, name)
+    if not owner or not name then
+      callback({})
+      return
+    end
+
+    -- Build batched alias query (chunks of 25 to avoid oversized queries)
+    local all_counts = {}
+    local chunks = {}
+    for i = 1, #issue_numbers, 25 do
+      local chunk = {}
+      for j = i, math.min(i + 24, #issue_numbers) do
+        table.insert(chunk, issue_numbers[j])
+      end
+      table.insert(chunks, chunk)
+    end
+
+    local pending = #chunks
+    if pending == 0 then
+      callback({})
+      return
+    end
+
+    for _, chunk in ipairs(chunks) do
+      local aliases = {}
+      for _, num in ipairs(chunk) do
+        table.insert(
+          aliases,
+          string.format("i%d: issue(number: %d) { subIssuesSummary { total completed } }", num, num)
+        )
+      end
+
+      local query =
+        string.format('{ repository(owner: "%s", name: "%s") { %s } }', owner, name, table.concat(aliases, " "))
+
+      local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), {
+        "api",
+        "graphql",
+        "-H",
+        "GraphQL-Features: sub_issues",
+        "-f",
+        "query=" .. query,
+      })
+
+      vim.system(cmd, { text = true }, function(result)
+        vim.schedule(function()
+          if result.code == 0 and result.stdout then
+            local ok, data = pcall(vim.json.decode, result.stdout)
+            if ok and data and data.data and data.data.repository then
+              local repo = data.data.repository
+              for _, num in ipairs(chunk) do
+                local key = "i" .. num
+                if repo[key] and repo[key].subIssuesSummary then
+                  local s = repo[key].subIssuesSummary
+                  if s.total and s.total > 0 then
+                    all_counts[num] = { total = s.total, completed = s.completed or 0 }
+                  end
+                end
+              end
+            end
+          end
+
+          pending = pending - 1
+          if pending == 0 then
+            callback(all_counts)
+          end
+        end)
+      end)
+    end
+  end)
+end
+
+-- ---------------------------------------------------------------------------
 -- Label management
 -- ---------------------------------------------------------------------------
 

--- a/lua/okuban/api_project.lua
+++ b/lua/okuban/api_project.lua
@@ -263,6 +263,7 @@ local function build_items_query(field_name)
     .. "              number title body state\n"
     .. "              assignees(first: 5) { nodes { login } }\n"
     .. "              labels(first: 10) { nodes { name color } }\n"
+    .. "              subIssuesSummary { total completed }\n"
     .. "            }\n"
     .. "            ... on DraftIssue { title body }\n"
     .. "          }\n"
@@ -282,6 +283,8 @@ function M.fetch_items_page(project_id, cursor, callback)
   local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), {
     "api",
     "graphql",
+    "-H",
+    "GraphQL-Features: sub_issues",
     "-f",
     "query=" .. query,
     "-F",
@@ -373,6 +376,14 @@ local function transform_item(item)
     assignees = assignees,
     labels = labels,
   }
+
+  -- Embed sub-issue counts if available
+  if content.subIssuesSummary and content.subIssuesSummary.total and content.subIssuesSummary.total > 0 then
+    issue.sub_issue_counts = {
+      total = content.subIssuesSummary.total,
+      completed = content.subIssuesSummary.completed or 0,
+    }
+  end
 
   local status_option_id = nil
   if item.fieldValueByName and type(item.fieldValueByName) == "table" then

--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -119,6 +119,7 @@ function Board.new()
   o.preview_buf = nil
   o._poll_timer = nil
   o._polling = false
+  o.sub_issue_counts = {}
   return o
 end
 
@@ -249,7 +250,8 @@ function Board:update_preview(issue)
   local layout = Board.calculate_layout(num_cols, nil, nil, preview_lines)
   local inner_width = layout.board_width - 2
   local sessions = claude.get_all_sessions()
-  local lines = card.render_preview(issue, inner_width, layout.preview_height, self.worktree_map, sessions)
+  local lines =
+    card.render_preview(issue, inner_width, layout.preview_height, self.worktree_map, sessions, self.sub_issue_counts)
 
   vim.bo[self.preview_buf].modifiable = true
   vim.api.nvim_buf_set_lines(self.preview_buf, 0, -1, false, lines)
@@ -484,7 +486,7 @@ function Board:populate(data)
 
     if buf and vim.api.nvim_buf_is_valid(buf) then
       local inner_width = layout.col_width - 2
-      local lines, card_ranges = card.render_column(col.issues, inner_width, wt_map, sessions)
+      local lines, card_ranges = card.render_column(col.issues, inner_width, wt_map, sessions, self.sub_issue_counts)
       col.card_ranges = card_ranges
 
       vim.bo[buf].modifiable = true
@@ -523,7 +525,8 @@ function Board:populate(data)
       local buf = self.buffers[i]
       if buf and vim.api.nvim_buf_is_valid(buf) then
         local inner_width = layout.col_width - 2
-        local lines, card_ranges = card.render_column(col.issues, inner_width, enriched_map, sessions)
+        local lines, card_ranges =
+          card.render_column(col.issues, inner_width, enriched_map, sessions, self.sub_issue_counts)
         col.card_ranges = card_ranges
         vim.bo[buf].modifiable = true
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
@@ -537,6 +540,43 @@ function Board:populate(data)
       self.navigation:highlight_current()
     end
   end)
+
+  -- Fetch sub-issue counts asynchronously
+  local all_numbers = {}
+  for _, col in ipairs(cols) do
+    for _, issue in ipairs(col.issues) do
+      table.insert(all_numbers, issue.number)
+    end
+  end
+  if #all_numbers > 0 then
+    local api = require("okuban.api")
+    api.fetch_sub_issue_counts(all_numbers, function(counts)
+      if not self:is_open() then
+        return
+      end
+      if not counts or vim.tbl_isempty(counts) then
+        return
+      end
+      self.sub_issue_counts = counts
+      -- Re-render columns with sub-issue badges
+      local re_sessions = claude.get_all_sessions()
+      for i, col in ipairs(self.columns) do
+        local buf = self.buffers[i]
+        if buf and vim.api.nvim_buf_is_valid(buf) then
+          local re_layout = Board.calculate_layout(#self.columns, nil, nil, cfg.preview_lines or 0)
+          local iw = re_layout.col_width - 2
+          local lines, card_ranges = card.render_column(col.issues, iw, self.worktree_map, re_sessions, counts)
+          col.card_ranges = card_ranges
+          vim.bo[buf].modifiable = true
+          vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+          vim.bo[buf].modifiable = false
+        end
+      end
+      if self.navigation then
+        self.navigation:highlight_current()
+      end
+    end)
+  end
 
   -- Set up or update navigation, preserving position during refresh
   local Navigation = require("okuban.ui.navigation")
@@ -594,7 +634,7 @@ function Board:open(data)
     vim.bo[buf].filetype = "okuban"
 
     local inner_width = layout.col_width - 2
-    local lines, card_ranges = card.render_column(col.issues, inner_width, wt_map, sessions)
+    local lines, card_ranges = card.render_column(col.issues, inner_width, wt_map, sessions, self.sub_issue_counts)
     col.card_ranges = card_ranges
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
     vim.bo[buf].modifiable = false

--- a/lua/okuban/ui/card.lua
+++ b/lua/okuban/ui/card.lua
@@ -144,10 +144,18 @@ end
 ---@param width integer Available width for text
 ---@param worktree_map table<integer, table>|nil Map of issue number → worktree info
 ---@param claude_sessions table<integer, table>|nil Map of issue number → session info
+---@param sub_issue_counts table<integer, {total: integer, completed: integer}>|nil
 ---@return string
-function M.render_card(issue, width, worktree_map, claude_sessions)
+function M.render_card(issue, width, worktree_map, claude_sessions, sub_issue_counts)
   local title = M.strip_commit_prefix(issue.title or "")
   local prefix = " #" .. issue.number .. " "
+
+  -- Sub-issue count badge (after title, before worktree/session badges)
+  local sub_badge = ""
+  local sub_info = (sub_issue_counts and sub_issue_counts[issue.number]) or issue.sub_issue_counts
+  if sub_info and sub_info.total and sub_info.total > 0 then
+    sub_badge = " (" .. sub_info.total .. ")"
+  end
 
   -- Check for worktree badge (active worktrees use highlight color instead of badge)
   local badge = ""
@@ -175,14 +183,14 @@ function M.render_card(issue, width, worktree_map, claude_sessions)
     end
   end
 
-  local avail = width - #prefix - #badge
+  local avail = width - #prefix - #sub_badge - #badge
   if avail < 1 then
-    return prefix .. badge
+    return prefix .. sub_badge .. badge
   end
   if #title > avail then
     title = title:sub(1, avail - 1) .. ELLIPSIS
   end
-  return prefix .. title .. badge
+  return prefix .. title .. sub_badge .. badge
 end
 
 --- Render all cards for a column as a compact list (one line per card).
@@ -190,9 +198,10 @@ end
 ---@param width integer Available width for text
 ---@param worktree_map table<integer, table>|nil Map of issue number → worktree info
 ---@param claude_sessions table<integer, table>|nil Map of issue number → session info
+---@param sub_issue_counts table<integer, {total: integer, completed: integer}>|nil
 ---@return string[] lines
 ---@return table[] card_ranges Array of { start_line: integer, end_line: integer } (1-indexed)
-function M.render_column(issues, width, worktree_map, claude_sessions)
+function M.render_column(issues, width, worktree_map, claude_sessions, sub_issue_counts)
   if #issues == 0 then
     return { "  (no issues)" }, {}
   end
@@ -200,7 +209,7 @@ function M.render_column(issues, width, worktree_map, claude_sessions)
   local lines = {}
   local card_ranges = {}
   for i, issue in ipairs(issues) do
-    table.insert(lines, M.render_card(issue, width, worktree_map, claude_sessions))
+    table.insert(lines, M.render_card(issue, width, worktree_map, claude_sessions, sub_issue_counts))
     table.insert(card_ranges, { start_line = i, end_line = i })
   end
   return lines, card_ranges
@@ -213,8 +222,9 @@ end
 ---@param height integer Number of lines in preview pane
 ---@param worktree_map table<integer, table>|nil Map of issue number → worktree info
 ---@param claude_sessions table<integer, table>|nil Map of issue number → session info
+---@param sub_issue_counts table<integer, {total: integer, completed: integer}>|nil
 ---@return string[]
-function M.render_preview(issue, width, height, worktree_map, claude_sessions)
+function M.render_preview(issue, width, height, worktree_map, claude_sessions, sub_issue_counts)
   if not issue then
     local lines = {}
     for _ = 1, height do
@@ -284,6 +294,13 @@ function M.render_preview(issue, width, height, worktree_map, claude_sessions)
     end
     table.insert(lines, "")
     table.insert(lines, table.concat(parts, " \xc2\xb7 "))
+  end
+
+  -- Sub-issue progress
+  local sub_info = (sub_issue_counts and sub_issue_counts[issue.number]) or issue.sub_issue_counts
+  if sub_info and sub_info.total and sub_info.total > 0 and #lines < height - 1 then
+    table.insert(lines, "")
+    table.insert(lines, string.format("%d/%d sub-issues", sub_info.completed, sub_info.total))
   end
 
   -- Claude session status

--- a/tests/test_api_fetch_spec.lua
+++ b/tests/test_api_fetch_spec.lua
@@ -333,6 +333,94 @@ describe("okuban.api fetch", function()
     end)
   end)
 
+  describe("fetch_sub_issue_counts", function()
+    it("returns empty table on empty input", function()
+      local done = false
+      local result = nil
+      -- Need api_labels module directly for label-mode fetch
+      local api_labels = require("okuban.api_labels")
+      api_labels.fetch_sub_issue_counts({}, function(counts)
+        done = true
+        result = counts
+      end)
+
+      vim.wait(1000, function()
+        return done
+      end)
+      assert.is_not_nil(result)
+      assert.equals(0, vim.tbl_count(result))
+    end)
+
+    it("parses GraphQL response correctly", function()
+      -- First call: detect_repo_info (gh repo view)
+      -- Second call: GraphQL query
+      local graphql_response = vim.json.encode({
+        data = {
+          repository = {
+            i10 = { subIssuesSummary = { total = 3, completed = 1 } },
+            i20 = { subIssuesSummary = { total = 0, completed = 0 } },
+            i30 = { subIssuesSummary = { total = 5, completed = 5 } },
+          },
+        },
+      })
+      helpers.mock_vim_system({
+        { code = 0, stdout = "alice|myrepo" }, -- detect_repo_info
+        { code = 0, stdout = graphql_response }, -- GraphQL query
+      })
+
+      local api_labels = require("okuban.api_labels")
+      -- Reset repo info cache
+      api._reset_repo_info()
+
+      local done = false
+      local result = nil
+      api_labels.fetch_sub_issue_counts({ 10, 20, 30 }, function(counts)
+        done = true
+        result = counts
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      assert.is_not_nil(result)
+      -- Issue 10: total=3 > 0, should be in result
+      assert.is_not_nil(result[10])
+      assert.equals(3, result[10].total)
+      assert.equals(1, result[10].completed)
+      -- Issue 20: total=0, should NOT be in result
+      assert.is_nil(result[20])
+      -- Issue 30: total=5 > 0, should be in result
+      assert.is_not_nil(result[30])
+      assert.equals(5, result[30].total)
+      assert.equals(5, result[30].completed)
+    end)
+
+    it("handles API errors gracefully", function()
+      helpers.mock_vim_system({
+        { code = 0, stdout = "alice|myrepo" }, -- detect_repo_info
+        { code = 1, stderr = "GraphQL error" }, -- GraphQL fails
+      })
+
+      local api_labels = require("okuban.api_labels")
+      api._reset_repo_info()
+
+      local done = false
+      local result = nil
+      api_labels.fetch_sub_issue_counts({ 10, 20 }, function(counts)
+        done = true
+        result = counts
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      assert.is_not_nil(result)
+      assert.equals(0, vim.tbl_count(result))
+    end)
+  end)
+
   describe("create_all_labels", function()
     it("creates 5 kanban labels by default", function()
       local responses = {}

--- a/tests/test_card_render_spec.lua
+++ b/tests/test_card_render_spec.lua
@@ -287,6 +287,37 @@ describe("okuban.ui.card", function()
       assert.is_falsy(result:match("\xe2\x9c\x93"))
       assert.is_falsy(result:match("\xe2\x9c\x97"))
     end)
+
+    it("shows sub-issue count badge from counts map", function()
+      local counts = { [42] = { total = 3, completed = 1 } }
+      local result = card_mod.render_card({ number = 42, title = "Test" }, 40, nil, nil, counts)
+      assert.truthy(result:match("%(3%)"))
+    end)
+
+    it("shows sub-issue count badge from issue.sub_issue_counts (project mode)", function()
+      local issue = { number = 42, title = "Test", sub_issue_counts = { total = 5, completed = 2 } }
+      local result = card_mod.render_card(issue, 40)
+      assert.truthy(result:match("%(5%)"))
+    end)
+
+    it("no sub-issue badge when count is 0", function()
+      local counts = { [42] = { total = 0, completed = 0 } }
+      local result = card_mod.render_card({ number = 42, title = "Test" }, 40, nil, nil, counts)
+      assert.is_falsy(result:match("%(0%)"))
+    end)
+
+    it("no sub-issue badge when counts is nil", function()
+      local result = card_mod.render_card({ number = 42, title = "Test" }, 40, nil, nil, nil)
+      assert.is_falsy(result:match("%(%d+%)"))
+    end)
+
+    it("truncates title correctly with sub-issue badge", function()
+      local counts = { [1] = { total = 3, completed = 1 } }
+      local result =
+        card_mod.render_card({ number = 1, title = "A very long title that will be truncated" }, 25, nil, nil, counts)
+      assert.truthy(result:match("%(3%)"))
+      assert.truthy(result:match("\xe2\x80\xa6")) -- ellipsis
+    end)
   end)
 
   describe("render_column", function()
@@ -328,6 +359,17 @@ describe("okuban.ui.card", function()
       local lines, _ = card_mod.render_column(issues, 30)
       assert.truthy(lines[1]:match("#10"))
       assert.truthy(lines[2]:match("#20"))
+    end)
+
+    it("passes sub_issue_counts through to cards", function()
+      local issues = {
+        { number = 10, title = "Alpha" },
+        { number = 20, title = "Beta" },
+      }
+      local counts = { [10] = { total = 3, completed = 1 } }
+      local lines, _ = card_mod.render_column(issues, 40, nil, nil, counts)
+      assert.truthy(lines[1]:match("%(3%)"))
+      assert.is_falsy(lines[2]:match("%(%d+%)"))
     end)
   end)
 
@@ -405,6 +447,45 @@ describe("okuban.ui.card", function()
       local issue = { number = 1, title = "Short", assignees = {}, labels = {} }
       local lines = card_mod.render_preview(issue, 80, 10)
       assert.equals(10, #lines)
+    end)
+
+    it("shows sub-issue progress from counts map", function()
+      local issue = { number = 42, title = "Test", assignees = {}, labels = {} }
+      local counts = { [42] = { total = 5, completed = 2 } }
+      local lines = card_mod.render_preview(issue, 80, 10, nil, nil, counts)
+      local found = false
+      for _, line in ipairs(lines) do
+        if line:match("2/5 sub%-issues") then
+          found = true
+        end
+      end
+      assert.is_true(found)
+    end)
+
+    it("shows sub-issue progress from issue.sub_issue_counts (project mode)", function()
+      local issue = {
+        number = 42,
+        title = "Test",
+        assignees = {},
+        labels = {},
+        sub_issue_counts = { total = 3, completed = 3 },
+      }
+      local lines = card_mod.render_preview(issue, 80, 10)
+      local found = false
+      for _, line in ipairs(lines) do
+        if line:match("3/3 sub%-issues") then
+          found = true
+        end
+      end
+      assert.is_true(found)
+    end)
+
+    it("no sub-issue line when counts are 0 or nil", function()
+      local issue = { number = 42, title = "Test", assignees = {}, labels = {} }
+      local lines = card_mod.render_preview(issue, 80, 10, nil, nil, nil)
+      for _, line in ipairs(lines) do
+        assert.is_falsy(line:match("sub%-issues"))
+      end
     end)
 
     it("respects show_tldr config", function()


### PR DESCRIPTION
## Summary
- Show `(N)` badge on kanban cards that have sub-issues, with richer `X/Y sub-issues` progress in the preview pane
- Label mode: batched GraphQL aliases with `subIssuesSummary` (one call for all visible issues, chunked in groups of 25)
- Project mode: extends existing GraphQL query with `subIssuesSummary` — zero extra API calls
- Graceful degradation: if sub-issues API is unavailable, no badges shown, no errors

Fixes #54

## Test plan
- [x] 9 new card render tests (badge from map, project mode, 0/nil, truncation, column pass-through, preview progress)
- [x] 3 new API fetch tests (empty input, GraphQL parse, error handling)
- [x] All 357 existing + new tests pass (`make check`)
- [ ] Manual: open board on repo with sub-issues → verify `(N)` badges
- [ ] Manual: open board on repo without sub-issues → no badges, no errors
- [ ] Manual: verify preview pane shows `2/5 sub-issues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)