### PR TITLE
chore: improve GitHub workflow sync for skills, hooks, and instructions

### DIFF
--- a/.claude/hooks/github-hygiene.sh
+++ b/.claude/hooks/github-hygiene.sh
@@ -130,6 +130,57 @@ if [ -n "$OPEN_DONE" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# 7. Check for orphaned remote branches (issue is closed)
+# ---------------------------------------------------------------------------
+git fetch --prune 2>/dev/null
+
+REMOTE_BRANCHES=$(git branch -r 2>/dev/null | sed 's/^[[:space:]]*//' | grep -v 'origin/main$' | grep -v 'origin/HEAD' | grep -v 'release-please')
+
+if [ -n "$REMOTE_BRANCHES" ]; then
+  while IFS= read -r BRANCH; do
+    ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-([0-9]+)' | grep -oE '[0-9]+')
+    if [ -n "$ISSUE_NUM" ]; then
+      STATE=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json state --jq '.state' 2>/dev/null)
+      if [ "$STATE" = "CLOSED" ]; then
+        LOCAL_BRANCH="${BRANCH#origin/}"
+        WARNINGS="${WARNINGS}\n  - Remote branch ${BRANCH} is orphaned (issue #${ISSUE_NUM} is closed)"
+        ACTIONS="${ACTIONS}\n  - Delete: git push origin --delete ${LOCAL_BRANCH}"
+      fi
+    fi
+  done <<< "$REMOTE_BRANCHES"
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Check for duplicate open PRs referencing the same issue
+# ---------------------------------------------------------------------------
+OPEN_PR_JSON=$(gh pr list --repo "$REPO" --state open --json number,title,body,headRefName 2>/dev/null)
+
+if [ -n "$OPEN_PR_JSON" ] && [ "$OPEN_PR_JSON" != "[]" ]; then
+  # Extract issue numbers from PR bodies and branch names, group by issue
+  ISSUE_PR_MAP=$(echo "$OPEN_PR_JSON" | jq -r '
+    [.[] | {
+      pr: .number,
+      title: .title,
+      issues: (
+        [(.body // "" | capture("(?:Fixes|Closes|Resolves)\\s*#(?<num>[0-9]+)"; "gi") | .num)] +
+        [(.headRefName // "" | capture("issue-(?<num>[0-9]+)"; "g") | .num)]
+      ) | unique
+    }] |
+    group_by(.issues[]) |
+    map(select(length > 1)) |
+    .[] |
+    "issue#\(.[0].issues[0])|\([ .[] | "#\(.pr) (\(.title))" ] | join(", "))"
+  ' 2>/dev/null)
+
+  if [ -n "$ISSUE_PR_MAP" ]; then
+    while IFS='|' read -r ISSUE_REF PR_LIST; do
+      WARNINGS="${WARNINGS}\n  - Multiple open PRs for ${ISSUE_REF}: ${PR_LIST}"
+      ACTIONS="${ACTIONS}\n  - Review and close duplicate PRs for ${ISSUE_REF}"
+    done <<< "$ISSUE_PR_MAP"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # Output results
 # ---------------------------------------------------------------------------
 if [ -n "$WARNINGS" ]; then

--- a/.claude/skills/close-issue/SKILL.md
+++ b/.claude/skills/close-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: close-issue
-description: Close a GitHub issue after work is complete. Moves the kanban label to done, comments on the issue, and closes it.
+description: Close a GitHub issue after work is complete. Moves the kanban label to done, closes stale PRs, deletes feature branches, and closes the issue.
 argument-hint: "<issue-number>"
 allowed-tools: Bash, Read, Grep
 ---
@@ -23,43 +23,92 @@ gh issue view $ARGUMENTS --json number,title,state,labels
 ### 2. Check for linked PRs
 
 ```bash
-gh pr list --search "Fixes #$ARGUMENTS OR Closes #$ARGUMENTS" --json number,title,state,url
+gh pr list --search "Fixes #$ARGUMENTS OR Closes #$ARGUMENTS" --state all --json number,title,state,url,headRefName
 ```
 
-- If open PRs exist, warn: "There are open PRs linked to this issue. Close them first or merge them?"
-- If merged PRs exist, note them as evidence of completion
+Also check by branch name convention:
 
-### 3. Move the kanban label to Done
+```bash
+gh pr list --head "issue-$ARGUMENTS" --state all --json number,title,state,url,headRefName
+```
+
+- If merged PRs exist, note them as evidence of completion
+- If open PRs exist, they will be closed in the next step
+
+### 3. Close stale open PRs linked to this issue
+
+For each **open** PR found in step 2:
+
+```bash
+gh pr close <PR_NUMBER> --comment "Superseded — issue #$ARGUMENTS closed directly."
+```
+
+Collect the `headRefName` from each closed PR for branch cleanup in step 5.
+
+### 4. Move the kanban label to Done
 
 Remove any existing `okuban:` label and add `okuban:done`:
 
 ```bash
-gh issue edit $ARGUMENTS --remove-label "okuban:in-progress" --add-label "okuban:done"
+gh issue edit $ARGUMENTS --remove-label "okuban:backlog" --remove-label "okuban:todo" --remove-label "okuban:in-progress" --remove-label "okuban:review" --add-label "okuban:done"
 ```
 
-### 4. Comment and close
+### 5. Comment and close
 
 ```bash
 gh issue comment $ARGUMENTS --body "Work completed. Closing this issue."
 gh issue close $ARGUMENTS --reason "completed"
 ```
 
-### 5. Clean up feature branch
+### 6. Delete remote feature branches for this issue
 
-Switch to `main` and delete the local feature branch:
+For each branch name collected from PRs in step 2/3, plus any remote branches matching the issue pattern:
+
+```bash
+# Find remote branches matching the issue number
+git fetch --prune
+git branch -r --list "*issue-$ARGUMENTS*"
+```
+
+For each matching remote branch (skip `main`, `HEAD`, `release-please`):
+
+```bash
+git push origin --delete <branch-name>
+```
+
+### 7. Clean up local feature branches
+
+Switch to `main` and pull latest:
 
 ```bash
 git checkout main
 git pull
-git branch -D <feature-branch>
 ```
 
-The remote branch is auto-deleted by GitHub on PR merge (`delete_branch_on_merge` is enabled).
+Find and delete **all** local branches matching this issue:
 
-### 6. Confirm
+```bash
+git branch --list "*issue-$ARGUMENTS*"
+```
+
+For each matching branch (skip the current branch):
+
+```bash
+git branch -D <branch>
+```
+
+Prune stale remote tracking refs:
+
+```bash
+git fetch --prune
+```
+
+### 8. Confirm
 
 Print a summary:
 - Issue: #NUMBER — TITLE
 - Status: **Closed** (completed)
 - Kanban: moved to **Done**
-- Branch: deleted (local + remote)
+- PRs closed: list any PRs closed in step 3 (or "none")
+- Remote branches deleted: list branches deleted in step 6 (or "none")
+- Local branches deleted: list branches deleted in step 7 (or "none")

--- a/.claude/skills/start-issue/SKILL.md
+++ b/.claude/skills/start-issue/SKILL.md
@@ -21,13 +21,52 @@ gh issue view $ARGUMENTS --json number,title,body,state,labels,assignees
 - If the issue is closed, warn the user and ask whether to reopen it
 - Summarize the issue title, description, and acceptance criteria
 
-### 2. Assign yourself
+### 2. Verify clean starting state
+
+Ensure we're on the default branch with a clean working tree:
+
+```bash
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
+CURRENT=$(git branch --show-current)
+```
+
+- If not on the default branch: switch to it and pull latest
+  ```bash
+  git checkout $DEFAULT_BRANCH
+  git pull
+  ```
+- If the working tree is dirty (`git status --porcelain` has output): warn the user and ask before proceeding (uncommitted changes could be lost)
+
+### 3. Check for existing work on this issue
+
+Look for open PRs already linked to this issue:
+
+```bash
+gh pr list --search "Fixes #$ARGUMENTS OR Closes #$ARGUMENTS" --state open --json number,title,headRefName
+```
+
+Also check by branch name convention:
+
+```bash
+gh pr list --head "issue-$ARGUMENTS" --state open --json number,title,headRefName
+```
+
+And check for existing local branches:
+
+```bash
+git branch --list "*issue-$ARGUMENTS*"
+```
+
+- If an open PR exists: warn "PR #X already exists for this issue on branch `branch-name`. Continue anyway?" and ask the user
+- If a local branch exists but no PR: offer to switch to it instead of creating a new one
+
+### 4. Assign yourself
 
 ```bash
 gh issue edit $ARGUMENTS --add-assignee @me
 ```
 
-### 3. Apply the kanban label
+### 5. Apply the kanban label
 
 ```bash
 gh issue edit $ARGUMENTS --add-label "okuban:in-progress"
@@ -39,7 +78,7 @@ If the issue already has another `okuban:` label, remove it first:
 gh issue edit $ARGUMENTS --remove-label "okuban:todo" --add-label "okuban:in-progress"
 ```
 
-### 4. Create a feature branch
+### 6. Create a feature branch
 
 Derive a short slug from the issue title (lowercase, hyphens, no special chars, max 40 chars). Then:
 
@@ -49,13 +88,13 @@ git checkout -b feat/issue-$ARGUMENTS-<slug>
 
 Use `fix/` prefix instead of `feat/` if the issue has a `type: bug` label.
 
-### 5. Comment on the issue
+### 7. Comment on the issue
 
 ```bash
 gh issue comment $ARGUMENTS --body "Started working on this issue."
 ```
 
-### 6. Confirm
+### 8. Confirm
 
 Print a summary:
 - Issue: #NUMBER — TITLE

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,14 @@ If you find yourself on `main`, switch to a feature branch before making any cha
 - GitHub auto-closes the issue when the PR merges
 
 ### After Completing Work
-1. Move the kanban label: `gh issue edit <NUMBER> --remove-label "okuban:in-progress" --add-label "okuban:review"`
-2. Or use `/close-issue <NUMBER>` to automate closure
+1. After PR is merged, **always run `/close-issue <NUMBER>`** — this is the single cleanup command that:
+   - Moves the kanban label to `okuban:done`
+   - Closes the issue with a completion comment
+   - Closes any stale PRs linked to the issue
+   - Deletes remote and local feature branches
+   - Prunes stale git refs
+2. **Never skip `/close-issue`** — GitHub auto-close (via `Fixes #N`) only closes the issue, it does NOT move the kanban label or clean up branches/PRs
+3. For in-progress work not yet merged: `gh issue edit <NUMBER> --remove-label "okuban:in-progress" --add-label "okuban:review"`
 
 ### Why This Matters
 - Issues are the single source of truth for all project work


### PR DESCRIPTION
## Summary

- **`/close-issue` skill**: Now a complete cleanup command — closes stale PRs, deletes remote/local feature branches, prunes refs, in addition to labeling and closing
- **`/start-issue` skill**: Verifies clean starting state (on default branch, clean tree) and warns about existing PRs/branches for the issue before creating duplicates
- **`github-hygiene.sh` hook**: Detects orphaned remote branches (issue closed but branch still exists) and duplicate open PRs targeting the same issue
- **`CLAUDE.md`**: "After Completing Work" section now emphasizes `/close-issue` as the mandatory post-merge command, with explanation of why GitHub auto-close is insufficient

## Test plan

- [ ] Run `/close-issue` on a test issue — verify it closes PRs, deletes branches, prunes refs
- [ ] Start a new session on `main` — verify `github-hygiene.sh` detects orphaned branches (if any)
- [ ] Run `/start-issue` from a feature branch — verify it switches to main first
- [ ] Run `/start-issue` on an issue that already has a PR — verify warning
- [ ] Verify hook degrades gracefully without `jq` (exits 0)

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)