### PR TITLE
feat(ui): sub-issue tree expansion with column resize

### DIFF
--- a/lua/okuban/api.lua
+++ b/lua/okuban/api.lua
@@ -229,6 +229,14 @@ function M.fetch_sub_issue_counts(issue_numbers, callback)
   return require("okuban.api_labels").fetch_sub_issue_counts(issue_numbers, callback)
 end
 
+--- Fetch full sub-issue details for a single parent issue.
+--- Both label and project modes use the same GraphQL (subIssues is on the Issue type).
+---@param parent_number integer
+---@param callback fun(subs: table[])
+function M.fetch_sub_issues(parent_number, callback)
+  return require("okuban.api_labels").fetch_sub_issues(parent_number, callback)
+end
+
 --- Fetch issues for a single label (label-mode only).
 ---@param label string The label to filter by
 ---@param state string|nil Issue state filter

--- a/lua/okuban/api_labels.lua
+++ b/lua/okuban/api_labels.lua
@@ -338,6 +338,64 @@ function M.fetch_sub_issue_counts(issue_numbers, callback)
 end
 
 -- ---------------------------------------------------------------------------
+-- Sub-issue details
+-- ---------------------------------------------------------------------------
+
+--- Fetch full sub-issue details for a single parent issue via GraphQL.
+---@param parent_number integer
+---@param callback fun(subs: table[])
+function M.fetch_sub_issues(parent_number, callback)
+  local api = require("okuban.api")
+  api.detect_repo_info(function(owner, name)
+    if not owner or not name then
+      callback({})
+      return
+    end
+
+    local tmpl = '{ repository(owner: "%s", name: "%s") {'
+      .. " issue(number: %d) { subIssues(first: 50)"
+      .. " { nodes { number title state body } } } } }"
+    local query = string.format(tmpl, owner, name, parent_number)
+
+    local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), {
+      "api",
+      "graphql",
+      "-H",
+      "GraphQL-Features: sub_issues",
+      "-f",
+      "query=" .. query,
+    })
+
+    vim.system(cmd, { text = true }, function(result)
+      vim.schedule(function()
+        if result.code ~= 0 or not result.stdout then
+          callback({})
+          return
+        end
+        local ok, data = pcall(vim.json.decode, result.stdout)
+        if not ok or not data or not data.data or not data.data.repository then
+          callback({})
+          return
+        end
+        local issue = data.data.repository.issue
+        if not issue or not issue.subIssues or not issue.subIssues.nodes then
+          callback({})
+          return
+        end
+        -- Normalize vim.NIL → nil for optional fields (JSON null → vim.NIL in vim.json.decode)
+        local nodes = issue.subIssues.nodes
+        for _, node in ipairs(nodes) do
+          if node.body == vim.NIL then
+            node.body = nil
+          end
+        end
+        callback(nodes)
+      end)
+    end)
+  end)
+end
+
+-- ---------------------------------------------------------------------------
 -- Label management
 -- ---------------------------------------------------------------------------
 

--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -108,6 +108,60 @@ function Board.calculate_layout(num_cols, screen_width, screen_height, preview_l
   end
 end
 
+--- Compute per-column widths, optionally expanding one column.
+--- When focus_col is nil, all columns get equal width.
+--- When focus_col is set, that column gets extra width and others shrink.
+---@param num_cols integer
+---@param board_width integer Total board width
+---@param gap integer Gap between columns
+---@param focus_col integer|nil Column to expand (1-indexed)
+---@param multiplier number|nil Expansion multiplier (default 1.8)
+---@return integer[] widths Per-column widths
+function Board.compute_column_widths(num_cols, board_width, gap, focus_col, multiplier)
+  local total_gaps = (num_cols - 1) * gap
+  local available = board_width - total_gaps
+  local base_width = math.floor(available / num_cols)
+  local min_width = 20
+
+  if not focus_col or num_cols <= 1 then
+    local widths = {}
+    for _ = 1, num_cols do
+      table.insert(widths, base_width)
+    end
+    return widths
+  end
+
+  multiplier = multiplier or 1.8
+  local expanded = math.floor(base_width * multiplier)
+
+  -- Compute shrunk width for other columns
+  local shrunk = math.floor((available - expanded) / (num_cols - 1))
+
+  -- Enforce minimum width on shrunk columns
+  if shrunk < min_width then
+    shrunk = min_width
+    expanded = available - shrunk * (num_cols - 1)
+    -- If expanded is now smaller than base, don't bother expanding
+    if expanded <= base_width then
+      local widths = {}
+      for _ = 1, num_cols do
+        table.insert(widths, base_width)
+      end
+      return widths
+    end
+  end
+
+  local widths = {}
+  for i = 1, num_cols do
+    if i == focus_col then
+      table.insert(widths, expanded)
+    else
+      table.insert(widths, shrunk)
+    end
+  end
+  return widths
+end
+
 --- Create a new Board instance.
 ---@return table
 function Board.new()
@@ -121,6 +175,7 @@ function Board.new()
   o._poll_timer = nil
   o._polling = false
   o.sub_issue_counts = {}
+  o._expanded_col_idx = nil
   return o
 end
 
@@ -472,9 +527,13 @@ function Board:populate(data)
     return
   end
 
+  require("okuban.ui.tree").reset()
+  self._expanded_col_idx = nil
+
   local cfg = config.get()
   local preview_lines = cfg.preview_lines or 0
   local layout = Board.calculate_layout(#cols, nil, nil, preview_lines)
+  self._layout = layout
 
   -- Fetch worktree map (sync, ~4ms) for card badges
   local wt_map = worktree.fetch_worktree_map()
@@ -559,18 +618,21 @@ function Board:populate(data)
         return
       end
       self.sub_issue_counts = counts
-      -- Re-render columns with sub-issue badges
+      -- Re-render columns with sub-issue badges (skip tree-expanded columns)
       local re_sessions = claude.get_all_sessions()
+      local tree = require("okuban.ui.tree")
       for i, col in ipairs(self.columns) do
-        local buf = self.buffers[i]
-        if buf and vim.api.nvim_buf_is_valid(buf) then
-          local re_layout = Board.calculate_layout(#self.columns, nil, nil, cfg.preview_lines or 0)
-          local iw = re_layout.col_width - 2
-          local lines, card_ranges = card.render_column(col.issues, iw, self.worktree_map, re_sessions, counts)
-          col.card_ranges = card_ranges
-          vim.bo[buf].modifiable = true
-          vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-          vim.bo[buf].modifiable = false
+        -- Skip columns that have an active tree expansion (tree owns their buffer content)
+        if not col._visible_items or not tree.has_any_expanded(i) then
+          local buf = self.buffers[i]
+          if buf and vim.api.nvim_buf_is_valid(buf) then
+            local iw = self:get_column_width(i) - 2
+            local lines, card_ranges = card.render_column(col.issues, iw, self.worktree_map, re_sessions, counts)
+            col.card_ranges = card_ranges
+            vim.bo[buf].modifiable = true
+            vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+            vim.bo[buf].modifiable = false
+          end
         end
       end
       if self.navigation then
@@ -617,6 +679,7 @@ function Board:open(data)
   local cfg = config.get()
   local preview_lines = cfg.preview_lines or 0
   local layout = Board.calculate_layout(#cols, nil, nil, preview_lines)
+  self._layout = layout
   self.augroup = vim.api.nvim_create_augroup("OkubanBoard", { clear = true })
 
   -- Create header bar above columns
@@ -689,6 +752,7 @@ function Board:open(data)
 end
 
 --- Reposition all windows after a resize.
+--- Preserves column expansion state if a column is currently expanded.
 function Board:_reposition()
   if #self.windows == 0 then
     return
@@ -698,18 +762,22 @@ function Board:_reposition()
   local preview_lines = cfg.preview_lines or 0
   local num_cols = #self.windows
   local layout = Board.calculate_layout(num_cols, nil, nil, preview_lines)
+  self._layout = layout
 
+  local widths = Board.compute_column_widths(num_cols, layout.board_width, layout.gap, self._expanded_col_idx)
+
+  local col_offset = 0
   for i, win in ipairs(self.windows) do
     if vim.api.nvim_win_is_valid(win) then
-      local col_offset = (i - 1) * (layout.col_width + layout.gap)
       vim.api.nvim_win_set_config(win, {
         relative = "editor",
         row = layout.start_row,
         col = layout.start_col + col_offset,
-        width = layout.col_width,
+        width = widths[i],
         height = layout.board_height,
       })
     end
+    col_offset = col_offset + widths[i] + layout.gap
   end
 
   -- Reposition header window
@@ -726,15 +794,89 @@ function Board:_reposition()
     })
   end
 
+  -- Re-render expanded column with new width if applicable
+  if self._expanded_col_idx and self.navigation then
+    self.navigation:_rerender_column(self._expanded_col_idx)
+    self.navigation:highlight_current()
+  end
+
   -- Update scroll indicators after resize (window height may have changed)
   if self.navigation then
     self.navigation:update_scroll_indicators()
   end
 end
 
+--- Expand a column visually by making it wider and shrinking others.
+--- Updates all window positions and sizes via nvim_win_set_config.
+---@param col_idx integer Column to expand (1-indexed)
+function Board:_apply_column_expansion(col_idx)
+  if #self.windows == 0 or not self._layout then
+    return
+  end
+
+  self._expanded_col_idx = col_idx
+  local layout = self._layout
+  local num_cols = #self.windows
+  local widths = Board.compute_column_widths(num_cols, layout.board_width, layout.gap, col_idx)
+
+  local col_offset = 0
+  for i, win in ipairs(self.windows) do
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_set_config(win, {
+        relative = "editor",
+        row = layout.start_row,
+        col = layout.start_col + col_offset,
+        width = widths[i],
+        height = layout.board_height,
+      })
+    end
+    col_offset = col_offset + widths[i] + layout.gap
+  end
+end
+
+--- Restore all columns to equal width (undo expansion).
+function Board:_restore_column_widths()
+  if #self.windows == 0 or not self._layout then
+    return
+  end
+
+  self._expanded_col_idx = nil
+  local layout = self._layout
+  local num_cols = #self.windows
+  local widths = Board.compute_column_widths(num_cols, layout.board_width, layout.gap, nil)
+
+  local col_offset = 0
+  for i, win in ipairs(self.windows) do
+    if vim.api.nvim_win_is_valid(win) then
+      vim.api.nvim_win_set_config(win, {
+        relative = "editor",
+        row = layout.start_row,
+        col = layout.start_col + col_offset,
+        width = widths[i],
+        height = layout.board_height,
+      })
+    end
+    col_offset = col_offset + widths[i] + layout.gap
+  end
+end
+
+--- Get the current width of a specific column (expanded or normal).
+---@param col_idx integer
+---@return integer
+function Board:get_column_width(col_idx)
+  if not self._layout then
+    return 20
+  end
+  local num_cols = #self.windows
+  local widths =
+    Board.compute_column_widths(num_cols, self._layout.board_width, self._layout.gap, self._expanded_col_idx)
+  return widths[col_idx] or self._layout.col_width
+end
+
 --- Close the board and clean up all windows and buffers.
 function Board:close()
   self:_stop_polling()
+  require("okuban.ui.tree").reset()
 
   if self.augroup then
     vim.api.nvim_del_augroup_by_id(self.augroup)
@@ -753,6 +895,7 @@ function Board:close()
   end
   self.preview_win = nil
   self.preview_buf = nil
+  self._expanded_col_idx = nil
 
   for _, win in ipairs(self.windows) do
     if vim.api.nvim_win_is_valid(win) then

--- a/lua/okuban/ui/card.lua
+++ b/lua/okuban/ui/card.lua
@@ -71,7 +71,7 @@ end
 ---@param body string|nil
 ---@return string|nil
 function M.extract_tldr(body)
-  if not body or body == "" then
+  if not body or type(body) ~= "string" or body == "" then
     return nil
   end
 

--- a/lua/okuban/ui/navigation.lua
+++ b/lua/okuban/ui/navigation.lua
@@ -15,6 +15,7 @@ function Navigation.new(board)
   o.card_index = 1
   o.issue_mode = false
   o._expanding = false
+  o._tree_sub_index = 0
   return o
 end
 
@@ -38,6 +39,18 @@ end
 --- Move to the next column (right).
 function Navigation:move_right()
   if self.column_index < self:num_columns() then
+    -- Collapse any tree expansion and exit issue mode before changing column
+    local tree = require("okuban.ui.tree")
+    if tree.is_expanded(self.column_index, self:_current_parent_number()) or self._tree_sub_index > 0 then
+      tree.collapse_all(self.column_index)
+      self._tree_sub_index = 0
+      self.board:_restore_column_widths()
+      self:_rerender_column(self.column_index)
+    end
+    if self.issue_mode then
+      self:toggle_issue_mode()
+    end
+
     self.column_index = self.column_index + 1
     -- Clamp card_index to new column's size
     local count = self:card_count(self.column_index)
@@ -54,6 +67,18 @@ end
 --- Move to the previous column (left).
 function Navigation:move_left()
   if self.column_index > 1 then
+    -- Collapse any tree expansion and exit issue mode before changing column
+    local tree = require("okuban.ui.tree")
+    if tree.is_expanded(self.column_index, self:_current_parent_number()) or self._tree_sub_index > 0 then
+      tree.collapse_all(self.column_index)
+      self._tree_sub_index = 0
+      self.board:_restore_column_widths()
+      self:_rerender_column(self.column_index)
+    end
+    if self.issue_mode then
+      self:toggle_issue_mode()
+    end
+
     self.column_index = self.column_index - 1
     local count = self:card_count(self.column_index)
     if count == 0 then
@@ -68,6 +93,38 @@ end
 
 --- Move to the next card (down).
 function Navigation:move_down()
+  local tree = require("okuban.ui.tree")
+  local parent_num = self:_current_parent_number()
+
+  -- Tree navigation: entering or moving within sub-issues
+  if
+    parent_num
+    and tree.is_expanded(self.column_index, parent_num)
+    and not tree.is_loading(self.column_index, parent_num)
+  then
+    local subs = tree.get_cached(parent_num)
+    if subs and #subs > 0 then
+      if self._tree_sub_index == 0 then
+        -- Enter sub-issues from parent card
+        self._tree_sub_index = 1
+        self:highlight_current()
+        return
+      elseif self._tree_sub_index < #subs then
+        -- Move to next sub-issue
+        self._tree_sub_index = self._tree_sub_index + 1
+        self:highlight_current()
+        return
+      else
+        -- Past last sub-issue: collapse, restore widths, move to next card
+        tree.collapse(self.column_index, parent_num)
+        self._tree_sub_index = 0
+        self.board:_restore_column_widths()
+        self:_rerender_column(self.column_index)
+        -- Fall through to normal move_down logic
+      end
+    end
+  end
+
   local count = self:card_count(self.column_index)
   if self.card_index < count then
     self.card_index = self.card_index + 1
@@ -83,10 +140,180 @@ end
 
 --- Move to the previous card (up).
 function Navigation:move_up()
+  -- Tree navigation: moving within sub-issues
+  if self._tree_sub_index > 1 then
+    self._tree_sub_index = self._tree_sub_index - 1
+    self:highlight_current()
+    return
+  elseif self._tree_sub_index == 1 then
+    -- Back to parent card
+    self._tree_sub_index = 0
+    self:highlight_current()
+    return
+  end
+
   if self.card_index > 1 then
     self.card_index = self.card_index - 1
     self:highlight_current()
   end
+end
+
+--- Get the issue number of the current parent card (for tree operations).
+---@return integer|nil
+function Navigation:_current_parent_number()
+  local issue = self:get_selected_issue()
+  return issue and issue.number or nil
+end
+
+--- Toggle sub-issue tree expansion on the current card.
+--- If the card has sub-issues: expand/collapse the tree.
+--- If no sub-issues: just toggle issue mode.
+function Navigation:toggle_tree()
+  local issue = self:get_selected_issue()
+  if not issue then
+    local utils = require("okuban.utils")
+    utils.notify("No issue selected", vim.log.levels.WARN)
+    return
+  end
+
+  -- If we're on a sub-issue, ignore (sub-issues are display-only)
+  if self._tree_sub_index > 0 then
+    return
+  end
+
+  local tree = require("okuban.ui.tree")
+  local col_idx = self.column_index
+  local parent_num = issue.number
+
+  -- Check if this card has sub-issues (board-level map for labels mode,
+  -- issue-embedded counts for project mode)
+  local sub_count_info = (self.board.sub_issue_counts and self.board.sub_issue_counts[parent_num])
+    or issue.sub_issue_counts
+  local has_subs = sub_count_info and sub_count_info.total and sub_count_info.total > 0
+
+  if not has_subs then
+    -- No sub-issues: just toggle issue mode (existing behavior)
+    self:toggle_issue_mode()
+    return
+  end
+
+  -- If already expanded: collapse and restore column widths
+  if tree.is_expanded(col_idx, parent_num) then
+    tree.collapse(col_idx, parent_num)
+    self._tree_sub_index = 0
+    self.board:_restore_column_widths()
+    self:_rerender_column(col_idx)
+    if self.issue_mode then
+      self:toggle_issue_mode()
+    end
+    self:highlight_current()
+    return
+  end
+
+  -- Enter issue mode if not already
+  if not self.issue_mode then
+    self:toggle_issue_mode()
+  end
+
+  -- Expand the column visually before rendering tree content
+  self.board:_apply_column_expansion(col_idx)
+
+  -- Check cache first
+  local cached = tree.get_cached(parent_num)
+  if cached then
+    tree.set_expanded(col_idx, parent_num, cached)
+    self:_rerender_column(col_idx)
+    self:highlight_current()
+    return
+  end
+
+  -- Fetch sub-issues asynchronously
+  tree.set_loading(col_idx, parent_num)
+  self:_rerender_column(col_idx)
+  self:highlight_current()
+
+  local api = require("okuban.api")
+  api.fetch_sub_issues(parent_num, function(subs)
+    if not self.board:is_open() then
+      return
+    end
+    -- Verify we're still on the same card
+    if self.column_index ~= col_idx or self:_current_parent_number() ~= parent_num then
+      tree.collapse(col_idx, parent_num)
+      self.board:_restore_column_widths()
+      return
+    end
+    tree.set_expanded(col_idx, parent_num, subs or {})
+    self:_rerender_column(col_idx)
+    self:highlight_current()
+  end)
+end
+
+--- Re-render a single column buffer with tree-aware visible items.
+---@param col_idx integer
+function Navigation:_rerender_column(col_idx)
+  local col = self.board.columns[col_idx]
+  local buf = self.board.buffers[col_idx]
+  if not col or not buf or not vim.api.nvim_buf_is_valid(buf) then
+    return
+  end
+
+  local tree = require("okuban.ui.tree")
+  local card_mod = require("okuban.ui.card")
+  local claude = require("okuban.claude")
+
+  if not self.board._layout then
+    return
+  end
+  local col_width = self.board:get_column_width(col_idx)
+  local inner_width = col_width - 2
+  local sessions = claude.get_all_sessions()
+  local wt_map = self.board.worktree_map
+
+  local visible = tree.build_visible_items(col, col_idx)
+  local lines = {}
+  local card_ranges = {}
+
+  for _, item in ipairs(visible) do
+    if item.type == "card" then
+      local line = card_mod.render_card(item.issue, inner_width, wt_map, sessions, self.board.sub_issue_counts)
+      table.insert(lines, line)
+      card_ranges[item.card_idx] = { start_line = #lines, end_line = #lines }
+    elseif item.type == "sub_issue" then
+      table.insert(lines, tree.render_sub_issue_line(item.sub, item.is_last, inner_width))
+    elseif item.type == "loading" then
+      table.insert(lines, tree.render_loading_line(inner_width))
+    end
+  end
+
+  if #lines == 0 then
+    lines = { "  (no issues)" }
+  end
+
+  col.card_ranges = card_ranges
+  col._visible_items = visible
+
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].modifiable = false
+end
+
+--- Get the currently selected sub-issue (if navigating within a tree).
+---@return table|nil sub_issue
+function Navigation:_get_selected_sub()
+  if self._tree_sub_index <= 0 then
+    return nil
+  end
+  local tree = require("okuban.ui.tree")
+  local parent_num = self:_current_parent_number()
+  if not parent_num then
+    return nil
+  end
+  local cached = tree.get_cached(parent_num)
+  if not cached then
+    return nil
+  end
+  return cached[self._tree_sub_index]
 end
 
 --- Trigger lazy expansion of the current column.
@@ -130,6 +357,7 @@ end
 
 --- Highlight the currently focused card using extmarks.
 --- Supports multi-line cards via card_ranges on each column.
+--- When _tree_sub_index > 0, highlights the sub-issue line instead.
 function Navigation:highlight_current()
   -- Clear all highlights in all board buffers
   for _, buf in ipairs(self.board.buffers) do
@@ -148,6 +376,26 @@ function Navigation:highlight_current()
   local ranges = col and col.card_ranges
   local line_count = vim.api.nvim_buf_line_count(buf)
   local win = self.board.windows[self.column_index]
+
+  -- Sub-issue highlight: find the buffer line for the sub-issue
+  if self._tree_sub_index > 0 and col and col._visible_items then
+    local target_line = self:_find_sub_issue_line(col._visible_items)
+    if target_line and target_line > 0 and target_line <= line_count then
+      vim.api.nvim_buf_add_highlight(buf, ns_id, "OkubanCardFocused", target_line - 1, 0, -1)
+      if win and vim.api.nvim_win_is_valid(win) then
+        vim.api.nvim_win_set_cursor(win, { target_line, 0 })
+      end
+    end
+
+    -- Update preview with sub-issue content
+    local sub = self:_get_selected_sub()
+    if sub and self.board.update_preview then
+      self.board:update_preview(sub)
+    end
+
+    self:update_scroll_indicators()
+    return
+  end
 
   if ranges and ranges[self.card_index] then
     -- Multi-line card: highlight entire range
@@ -192,29 +440,48 @@ function Navigation:highlight_current()
   self:update_scroll_indicators()
 end
 
+--- Find the buffer line number for the current sub-issue in visible items.
+---@param visible_items table[]
+---@return integer|nil line 1-indexed buffer line
+function Navigation:_find_sub_issue_line(visible_items)
+  local parent_num = self:_current_parent_number()
+  if not parent_num then
+    return nil
+  end
+  local buf_line = 0
+  for _, item in ipairs(visible_items) do
+    buf_line = buf_line + 1
+    if item.type == "sub_issue" and item.parent_idx == self.card_index and item.position == self._tree_sub_index then
+      return buf_line
+    end
+  end
+  return nil
+end
+
 --- Update scroll indicator footers on all column windows.
---- Shows "↓ N more" when cards overflow below, "↑ N" when scrolled past top.
---- Uses partial nvim_win_set_config (valid in Neovim 0.10+: absent keys are unchanged).
+--- Shows "N more" when lines overflow below, "N" when scrolled past top.
+--- Uses actual buffer line count (accounts for tree-expanded items).
 function Navigation:update_scroll_indicators()
   for i, win in ipairs(self.board.windows) do
     if not win or not vim.api.nvim_win_is_valid(win) then
       goto continue
     end
 
-    local total_cards = self:card_count(i)
-    if total_cards == 0 then
+    local buf = self.board.buffers[i]
+    local total_lines = buf and vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_line_count(buf) or 0
+    if total_lines == 0 then
       pcall(vim.api.nvim_win_set_config, win, { footer = "" })
       goto continue
     end
 
     local win_height = vim.api.nvim_win_get_height(win)
-    if total_cards <= win_height then
+    if total_lines <= win_height then
       pcall(vim.api.nvim_win_set_config, win, { footer = "" })
     else
       local first_visible = vim.fn.line("w0", win)
       local last_visible = vim.fn.line("w$", win)
       local above = first_visible - 1
-      local below = total_cards - last_visible
+      local below = total_lines - last_visible
 
       local parts = {}
       if above > 0 then
@@ -246,6 +513,7 @@ function Navigation:focus_issue(issue_number)
       if issue.number == issue_number then
         self.column_index = col_idx
         self.card_index = card_idx
+        self._tree_sub_index = 0
         self:_focus_window()
         self:highlight_current()
         return true
@@ -322,10 +590,18 @@ function Navigation:setup_keymaps(buf)
     self.board:close()
   end, opts)
 
-  -- Esc: exit issue mode first, then close board
+  -- Esc: collapse tree → exit issue mode → close board (cascade)
   if keymaps.close ~= "<Esc>" then
     vim.keymap.set("n", "<Esc>", function()
-      if self.issue_mode then
+      local tree = require("okuban.ui.tree")
+      local parent_num = self:_current_parent_number()
+      if parent_num and tree.is_expanded(self.column_index, parent_num) then
+        tree.collapse(self.column_index, parent_num)
+        self._tree_sub_index = 0
+        self.board:_restore_column_widths()
+        self:_rerender_column(self.column_index)
+        self:highlight_current()
+      elseif self.issue_mode then
         self:toggle_issue_mode()
       else
         self.board:close()
@@ -347,9 +623,9 @@ function Navigation:setup_keymaps(buf)
     move.prompt_move(self.board)
   end, opts)
 
-  -- Enter: toggle issue mode (replaces action menu popup)
+  -- Enter: toggle tree expansion (or issue mode if no sub-issues)
   vim.keymap.set("n", keymaps.open_actions, function()
-    self:toggle_issue_mode()
+    self:toggle_tree()
   end, opts)
 
   -- Issue-mode action keymaps (v, c, a, x)
@@ -357,6 +633,10 @@ function Navigation:setup_keymaps(buf)
   for _, key in ipairs(action_keys) do
     vim.keymap.set("n", key, function()
       if not self.issue_mode then
+        return
+      end
+      -- Guard: no actions when on a sub-issue
+      if self._tree_sub_index > 0 then
         return
       end
       local issue = self:get_selected_issue()

--- a/lua/okuban/ui/tree.lua
+++ b/lua/okuban/ui/tree.lua
@@ -1,0 +1,173 @@
+--- Sub-issue tree expansion state and rendering.
+--- Manages expanded/collapsed state per column/parent, caches sub-issues,
+--- and builds the flat visible-item list for column rendering.
+local M = {}
+
+-- U+2026 HORIZONTAL ELLIPSIS (3 bytes in UTF-8)
+local ELLIPSIS = "\xe2\x80\xa6"
+
+--- Expansion state: expanded[col_idx][parent_number] = sub_issues[] | true (loading).
+---@type table<integer, table<integer, table[]|true>>
+local expanded = {}
+
+--- Session-scoped sub-issue cache (survives reset/refresh).
+---@type table<integer, table[]>
+local sub_cache = {}
+
+-- ---------------------------------------------------------------------------
+-- State management
+-- ---------------------------------------------------------------------------
+
+--- Reset expansion state (NOT cache). Call on board close/refresh.
+function M.reset()
+  expanded = {}
+end
+
+--- Check if a parent issue is expanded in a column.
+---@param col_idx integer
+---@param parent_number integer
+---@return boolean
+function M.is_expanded(col_idx, parent_number)
+  return expanded[col_idx] ~= nil and expanded[col_idx][parent_number] ~= nil
+end
+
+--- Check if a parent issue is in the loading state.
+---@param col_idx integer
+---@param parent_number integer
+---@return boolean
+function M.is_loading(col_idx, parent_number)
+  return expanded[col_idx] ~= nil and expanded[col_idx][parent_number] == true
+end
+
+--- Store sub-issues for an expanded parent and update cache.
+---@param col_idx integer
+---@param parent_number integer
+---@param subs table[] Array of { number, title, state, body }
+function M.set_expanded(col_idx, parent_number, subs)
+  if not expanded[col_idx] then
+    expanded[col_idx] = {}
+  end
+  expanded[col_idx][parent_number] = subs
+  sub_cache[parent_number] = subs
+end
+
+--- Mark a parent as loading (sentinel value `true`).
+---@param col_idx integer
+---@param parent_number integer
+function M.set_loading(col_idx, parent_number)
+  if not expanded[col_idx] then
+    expanded[col_idx] = {}
+  end
+  expanded[col_idx][parent_number] = true
+end
+
+--- Collapse a single parent in a column.
+---@param col_idx integer
+---@param parent_number integer
+function M.collapse(col_idx, parent_number)
+  if expanded[col_idx] then
+    expanded[col_idx][parent_number] = nil
+  end
+end
+
+--- Collapse all expansions in a column.
+---@param col_idx integer
+function M.collapse_all(col_idx)
+  expanded[col_idx] = nil
+end
+
+--- Check if any parent is expanded in a column.
+---@param col_idx integer
+---@return boolean
+function M.has_any_expanded(col_idx)
+  return expanded[col_idx] ~= nil and next(expanded[col_idx]) ~= nil
+end
+
+--- Get cached sub-issues for a parent (session-scoped).
+---@param parent_number integer
+---@return table[]|nil
+function M.get_cached(parent_number)
+  return sub_cache[parent_number]
+end
+
+-- ---------------------------------------------------------------------------
+-- Visible item list
+-- ---------------------------------------------------------------------------
+
+--- Build a flat list of visible items for a column, interleaving cards and
+--- expanded sub-issues.
+---@param col table Column with .issues array
+---@param col_idx integer
+---@return table[] items Array of { type = "card"|"sub_issue"|"loading", ... }
+function M.build_visible_items(col, col_idx)
+  local items = {}
+  for card_idx, issue in ipairs(col.issues) do
+    table.insert(items, { type = "card", issue = issue, card_idx = card_idx })
+
+    local exp = expanded[col_idx] and expanded[col_idx][issue.number]
+    if exp == true then
+      -- Loading placeholder
+      table.insert(items, { type = "loading", parent_idx = card_idx })
+    elseif type(exp) == "table" then
+      for pos, sub in ipairs(exp) do
+        table.insert(items, {
+          type = "sub_issue",
+          sub = sub,
+          parent_idx = card_idx,
+          position = pos,
+          is_last = (pos == #exp),
+        })
+      end
+    end
+  end
+  return items
+end
+
+-- ---------------------------------------------------------------------------
+-- Rendering helpers
+-- ---------------------------------------------------------------------------
+
+--- Render a single sub-issue line with tree characters.
+--- Format: " {tree_char} {state_icon} #{number} {title}"
+---@param sub table { number, title, state }
+---@param is_last boolean Whether this is the last sub-issue
+---@param width integer Available width
+---@return string
+function M.render_sub_issue_line(sub, is_last, width)
+  local tree_char = is_last and "\xe2\x94\x94" or "\xe2\x94\x9c" -- U+2514 / U+251C
+  local state_icon
+  if sub.state == "CLOSED" or sub.state == "closed" then
+    state_icon = "\xe2\x9c\x93" -- U+2713 CHECK MARK
+  else
+    state_icon = "\xe2\x97\x8b" -- U+25CB WHITE CIRCLE (open)
+  end
+
+  local num_str = tostring(sub.number)
+  local prefix = " " .. tree_char .. " " .. state_icon .. " #" .. num_str .. " "
+  local title = sub.title or ""
+
+  -- Compute display width: tree_char and state_icon are each 1 cell, rest is ASCII
+  -- " ├ ○ #NNN " → space(1) + tree(1) + space(1) + icon(1) + space(1) + #(1) + num + space(1)
+  local prefix_display = 7 + #num_str
+  local avail = width - prefix_display
+  if avail < 1 then
+    return prefix
+  end
+  if #title > avail then
+    title = title:sub(1, avail - 1) .. ELLIPSIS
+  end
+  return prefix .. title
+end
+
+--- Render a loading placeholder line.
+---@param width integer Available width
+---@return string
+function M.render_loading_line(width)
+  local line = " \xe2\x94\x94 loading..." -- U+2514
+  if #line > width then
+    return line:sub(1, width)
+  end
+  return line
+end
+
+return M

--- a/tests/test_api_fetch_spec.lua
+++ b/tests/test_api_fetch_spec.lua
@@ -421,6 +421,104 @@ describe("okuban.api fetch", function()
     end)
   end)
 
+  describe("fetch_sub_issues", function()
+    it("parses GraphQL response into sub-issue array", function()
+      local graphql_response = vim.json.encode({
+        data = {
+          repository = {
+            issue = {
+              subIssues = {
+                nodes = {
+                  { number = 11, title = "Sub one", state = "OPEN", body = "desc" },
+                  { number = 12, title = "Sub two", state = "CLOSED", body = "" },
+                },
+              },
+            },
+          },
+        },
+      })
+      helpers.mock_vim_system({
+        { code = 0, stdout = "alice|myrepo" }, -- detect_repo_info
+        { code = 0, stdout = graphql_response }, -- GraphQL query
+      })
+
+      api._reset_repo_info()
+      local done = false
+      local result = nil
+      api.fetch_sub_issues(42, function(subs)
+        done = true
+        result = subs
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      assert.is_not_nil(result)
+      assert.equals(2, #result)
+      assert.equals(11, result[1].number)
+      assert.equals("Sub one", result[1].title)
+      assert.equals("OPEN", result[1].state)
+      assert.equals(12, result[2].number)
+      assert.equals("CLOSED", result[2].state)
+    end)
+
+    it("returns empty array when no sub-issues", function()
+      local graphql_response = vim.json.encode({
+        data = {
+          repository = {
+            issue = {
+              subIssues = {
+                nodes = {},
+              },
+            },
+          },
+        },
+      })
+      helpers.mock_vim_system({
+        { code = 0, stdout = "alice|myrepo" },
+        { code = 0, stdout = graphql_response },
+      })
+
+      api._reset_repo_info()
+      local done = false
+      local result = nil
+      api.fetch_sub_issues(42, function(subs)
+        done = true
+        result = subs
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      assert.is_not_nil(result)
+      assert.equals(0, #result)
+    end)
+
+    it("returns empty array on API error", function()
+      helpers.mock_vim_system({
+        { code = 0, stdout = "alice|myrepo" },
+        { code = 1, stderr = "GraphQL error" },
+      })
+
+      api._reset_repo_info()
+      local done = false
+      local result = nil
+      api.fetch_sub_issues(42, function(subs)
+        done = true
+        result = subs
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      assert.is_not_nil(result)
+      assert.equals(0, #result)
+    end)
+  end)
+
   describe("create_all_labels", function()
     it("creates 5 kanban labels by default", function()
       local responses = {}

--- a/tests/test_board_layout_spec.lua
+++ b/tests/test_board_layout_spec.lua
@@ -124,4 +124,106 @@ describe("okuban.ui.board layout", function()
       assert.equals(layout.header_row + 4, layout.start_row)
     end)
   end)
+
+  describe("compute_column_widths", function()
+    it("returns equal widths when no focus column", function()
+      -- 5 columns, 108 board width, gap 1
+      -- available = 108 - 4*1 = 104, base = floor(104/5) = 20
+      local widths = Board.compute_column_widths(5, 108, 1, nil)
+      assert.equals(5, #widths)
+      for _, w in ipairs(widths) do
+        assert.equals(20, w)
+      end
+    end)
+
+    it("returns equal widths for single column", function()
+      local widths = Board.compute_column_widths(1, 108, 1, 1)
+      assert.equals(1, #widths)
+      assert.equals(108, widths[1])
+    end)
+
+    it("expands focused column with default 1.8x multiplier", function()
+      -- 5 columns, 108 board width, gap 1
+      -- available = 104, base = 20
+      -- expanded = floor(20 * 1.8) = 36
+      -- shrunk = floor((104 - 36) / 4) = floor(68/4) = 17 — BUT 17 < 20 (min_width)
+      -- min_width enforced: shrunk = 20, expanded = 104 - 20*4 = 24
+      local widths = Board.compute_column_widths(5, 108, 1, 3)
+      assert.equals(5, #widths)
+      -- Focus column (3) should be larger than others
+      assert.is_true(widths[3] > widths[1])
+      -- Non-focus columns should be >= 20 (min_width)
+      for i, w in ipairs(widths) do
+        if i ~= 3 then
+          assert.is_true(w >= 20, "Column " .. i .. " width " .. w .. " < 20")
+        end
+      end
+    end)
+
+    it("expands correctly with wider board", function()
+      -- 5 columns, 160 board width, gap 1
+      -- available = 156, base = floor(156/5) = 31
+      -- expanded = floor(31 * 1.8) = 55
+      -- shrunk = floor((156 - 55) / 4) = floor(101/4) = 25
+      -- 25 >= 20, so no min_width enforcement
+      local widths = Board.compute_column_widths(5, 160, 1, 2)
+      assert.equals(5, #widths)
+      assert.equals(55, widths[2])
+      assert.equals(25, widths[1])
+      assert.equals(25, widths[3])
+    end)
+
+    it("uses custom multiplier", function()
+      -- 5 columns, 160 board width, gap 1, multiplier 2.5
+      -- available = 156, base = 31
+      -- expanded = floor(31 * 2.5) = 77
+      -- shrunk = floor((156 - 77) / 4) = floor(79/4) = 19 — below 20!
+      -- min_width enforced: shrunk = 20, expanded = 156 - 20*4 = 76
+      local widths = Board.compute_column_widths(5, 160, 1, 1, 2.5)
+      assert.equals(5, #widths)
+      assert.equals(76, widths[1])
+      for i = 2, 5 do
+        assert.equals(20, widths[i])
+      end
+    end)
+
+    it("falls back to equal widths when expansion is impossible", function()
+      -- Very narrow: all columns already at minimum
+      -- 5 columns, 104 board width (100 available), gap 1
+      -- base = floor(100/5) = 20
+      -- expanded = floor(20 * 1.8) = 36
+      -- shrunk = floor((100 - 36) / 4) = 16 — below 20
+      -- min_width enforced: shrunk = 20, expanded = 100 - 80 = 20
+      -- expanded <= base (20 <= 20), so fall back to equal
+      local widths = Board.compute_column_widths(5, 104, 1, 3)
+      assert.equals(5, #widths)
+      for _, w in ipairs(widths) do
+        assert.equals(20, w)
+      end
+    end)
+
+    it("handles first column focus", function()
+      local widths = Board.compute_column_widths(5, 160, 1, 1)
+      -- Focus on column 1
+      assert.is_true(widths[1] > widths[2])
+    end)
+
+    it("handles last column focus", function()
+      local widths = Board.compute_column_widths(5, 160, 1, 5)
+      assert.is_true(widths[5] > widths[4])
+    end)
+
+    it("total widths plus gaps equal board_width or less", function()
+      local board_width = 160
+      local gap = 1
+      local num_cols = 5
+      local widths = Board.compute_column_widths(num_cols, board_width, gap, 3)
+      local total = 0
+      for _, w in ipairs(widths) do
+        total = total + w
+      end
+      total = total + (num_cols - 1) * gap
+      assert.is_true(total <= board_width)
+    end)
+  end)
 end)

--- a/tests/test_navigation_spec.lua
+++ b/tests/test_navigation_spec.lua
@@ -32,6 +32,17 @@ describe("okuban.ui.navigation", function()
       windows = windows,
       buffers = buffers,
       data = { columns = columns },
+      _expanded_col_idx = nil,
+      _layout = { board_width = 108, gap = 1, col_width = 20, start_row = 10, start_col = 6, board_height = 22 },
+      _restore_column_widths = function(self)
+        self._expanded_col_idx = nil
+      end,
+      _apply_column_expansion = function(self, col_idx)
+        self._expanded_col_idx = col_idx
+      end,
+      get_column_width = function()
+        return 20
+      end,
     }
   end
 
@@ -326,6 +337,116 @@ describe("okuban.ui.navigation", function()
       assert.has_no.errors(function()
         nav:update_scroll_indicators()
       end)
+    end)
+  end)
+
+  describe("tree navigation", function()
+    it("starts with _tree_sub_index = 0", function()
+      local board = mock_board({ 3 })
+      local nav = Navigation.new(board)
+      assert.equals(0, nav._tree_sub_index)
+    end)
+
+    it("move_down enters sub-issues when tree is expanded", function()
+      local board = mock_board({ 3 })
+      local nav = Navigation.new(board)
+      nav.highlight_current = function() end
+
+      -- Expand tree for issue 101 (col 1, card 1)
+      local tree = require("okuban.ui.tree")
+      tree.set_expanded(1, 101, {
+        { number = 201, title = "Sub1", state = "OPEN" },
+        { number = 202, title = "Sub2", state = "OPEN" },
+      })
+
+      nav:move_down()
+      assert.equals(1, nav._tree_sub_index)
+      assert.equals(1, nav.card_index)
+    end)
+
+    it("move_down navigates within sub-issues", function()
+      local board = mock_board({ 3 })
+      local nav = Navigation.new(board)
+      nav.highlight_current = function() end
+
+      local tree = require("okuban.ui.tree")
+      tree.set_expanded(1, 101, {
+        { number = 201, title = "Sub1", state = "OPEN" },
+        { number = 202, title = "Sub2", state = "OPEN" },
+      })
+
+      nav._tree_sub_index = 1
+      nav:move_down()
+      assert.equals(2, nav._tree_sub_index)
+      assert.equals(1, nav.card_index)
+    end)
+
+    it("move_down past last sub-issue collapses and moves to next card", function()
+      local board = mock_board({ 3 })
+      board.columns[1]._visible_items = nil
+      local nav = Navigation.new(board)
+      nav.highlight_current = function() end
+      nav._rerender_column = function() end
+
+      local tree = require("okuban.ui.tree")
+      tree.set_expanded(1, 101, {
+        { number = 201, title = "Sub1", state = "OPEN" },
+      })
+
+      nav._tree_sub_index = 1
+      nav:move_down()
+      assert.equals(0, nav._tree_sub_index)
+      assert.equals(2, nav.card_index)
+    end)
+
+    it("move_up from sub_index > 1 decrements", function()
+      local board = mock_board({ 3 })
+      local nav = Navigation.new(board)
+      nav.highlight_current = function() end
+
+      nav._tree_sub_index = 2
+      nav:move_up()
+      assert.equals(1, nav._tree_sub_index)
+    end)
+
+    it("move_up from sub_index 1 returns to parent", function()
+      local board = mock_board({ 3 })
+      local nav = Navigation.new(board)
+      nav.highlight_current = function() end
+
+      nav._tree_sub_index = 1
+      nav:move_up()
+      assert.equals(0, nav._tree_sub_index)
+      assert.equals(1, nav.card_index)
+    end)
+
+    it("column change resets _tree_sub_index", function()
+      local board = mock_board({ 3, 2 })
+      local nav = Navigation.new(board)
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+      nav._rerender_column = function() end
+
+      local tree = require("okuban.ui.tree")
+      tree.set_expanded(1, 101, {
+        { number = 201, title = "Sub1", state = "OPEN" },
+      })
+      nav._tree_sub_index = 1
+
+      nav:move_right()
+      assert.equals(0, nav._tree_sub_index)
+      assert.equals(2, nav.column_index)
+    end)
+
+    it("focus_issue resets _tree_sub_index", function()
+      local board = mock_board({ 3, 2 })
+      local nav = Navigation.new(board)
+      nav._focus_window = function() end
+      nav.highlight_current = function() end
+
+      nav._tree_sub_index = 2
+      nav:focus_issue(202) -- col 2, card 2
+      assert.equals(0, nav._tree_sub_index)
     end)
   end)
 

--- a/tests/test_tree_spec.lua
+++ b/tests/test_tree_spec.lua
@@ -1,0 +1,177 @@
+describe("okuban.ui.tree", function()
+  local tree
+
+  before_each(function()
+    package.loaded["okuban.ui.tree"] = nil
+    tree = require("okuban.ui.tree")
+  end)
+
+  describe("state management", function()
+    it("is_expanded returns false initially", function()
+      assert.is_false(tree.is_expanded(1, 42))
+    end)
+
+    it("set_expanded marks parent as expanded", function()
+      tree.set_expanded(1, 42, { { number = 1, title = "Sub", state = "OPEN" } })
+      assert.is_true(tree.is_expanded(1, 42))
+      assert.is_false(tree.is_loading(1, 42))
+    end)
+
+    it("set_loading marks parent as loading", function()
+      tree.set_loading(1, 42)
+      assert.is_true(tree.is_expanded(1, 42))
+      assert.is_true(tree.is_loading(1, 42))
+    end)
+
+    it("collapse removes expansion for one parent", function()
+      tree.set_expanded(1, 42, { { number = 1, title = "Sub", state = "OPEN" } })
+      tree.set_expanded(1, 43, { { number = 2, title = "Sub2", state = "OPEN" } })
+      tree.collapse(1, 42)
+      assert.is_false(tree.is_expanded(1, 42))
+      assert.is_true(tree.is_expanded(1, 43))
+    end)
+
+    it("collapse_all removes all expansions in a column", function()
+      tree.set_expanded(1, 42, { { number = 1, title = "Sub", state = "OPEN" } })
+      tree.set_expanded(1, 43, { { number = 2, title = "Sub2", state = "OPEN" } })
+      tree.collapse_all(1)
+      assert.is_false(tree.is_expanded(1, 42))
+      assert.is_false(tree.is_expanded(1, 43))
+    end)
+
+    it("has_any_expanded returns true when column has expansions", function()
+      tree.set_expanded(1, 42, { { number = 1, title = "Sub", state = "OPEN" } })
+      assert.is_true(tree.has_any_expanded(1))
+    end)
+
+    it("has_any_expanded returns false for empty column", function()
+      assert.is_false(tree.has_any_expanded(1))
+    end)
+
+    it("has_any_expanded returns false after collapse_all", function()
+      tree.set_expanded(1, 42, { { number = 1, title = "Sub", state = "OPEN" } })
+      tree.collapse_all(1)
+      assert.is_false(tree.has_any_expanded(1))
+    end)
+
+    it("reset clears expansion state but preserves cache", function()
+      tree.set_expanded(1, 42, { { number = 1, title = "Sub", state = "OPEN" } })
+      tree.reset()
+      assert.is_false(tree.is_expanded(1, 42))
+      -- Cache survives reset
+      local cached = tree.get_cached(42)
+      assert.is_not_nil(cached)
+      assert.equals(1, #cached)
+    end)
+
+    it("get_cached returns nil for unknown parent", function()
+      assert.is_nil(tree.get_cached(999))
+    end)
+
+    it("set_expanded populates cache", function()
+      local subs = { { number = 10, title = "A", state = "OPEN" } }
+      tree.set_expanded(1, 50, subs)
+      local cached = tree.get_cached(50)
+      assert.is_not_nil(cached)
+      assert.equals(1, #cached)
+      assert.equals(10, cached[1].number)
+    end)
+  end)
+
+  describe("build_visible_items", function()
+    it("returns card-only items when nothing expanded", function()
+      local col = {
+        issues = {
+          { number = 1, title = "A" },
+          { number = 2, title = "B" },
+        },
+      }
+      local items = tree.build_visible_items(col, 1)
+      assert.equals(2, #items)
+      assert.equals("card", items[1].type)
+      assert.equals(1, items[1].card_idx)
+      assert.equals("card", items[2].type)
+      assert.equals(2, items[2].card_idx)
+    end)
+
+    it("interleaves sub-issues when expanded", function()
+      local col = {
+        issues = {
+          { number = 10, title = "Parent" },
+          { number = 20, title = "Other" },
+        },
+      }
+      tree.set_expanded(1, 10, {
+        { number = 11, title = "Sub1", state = "OPEN" },
+        { number = 12, title = "Sub2", state = "CLOSED" },
+      })
+      local items = tree.build_visible_items(col, 1)
+      assert.equals(4, #items)
+      assert.equals("card", items[1].type)
+      assert.equals("sub_issue", items[2].type)
+      assert.equals(11, items[2].sub.number)
+      assert.is_false(items[2].is_last)
+      assert.equals("sub_issue", items[3].type)
+      assert.equals(12, items[3].sub.number)
+      assert.is_true(items[3].is_last)
+      assert.equals("card", items[4].type)
+    end)
+
+    it("includes loading placeholder", function()
+      local col = {
+        issues = { { number = 10, title = "Parent" } },
+      }
+      tree.set_loading(1, 10)
+      local items = tree.build_visible_items(col, 1)
+      assert.equals(2, #items)
+      assert.equals("card", items[1].type)
+      assert.equals("loading", items[2].type)
+    end)
+  end)
+
+  describe("render_sub_issue_line", function()
+    it("uses tree connector for non-last item", function()
+      local line = tree.render_sub_issue_line({ number = 14, title = "Layout", state = "OPEN" }, false, 40)
+      -- Should contain the box-drawing connector character (U+251C)
+      assert.truthy(line:find("\xe2\x94\x9c"))
+      assert.truthy(line:find("#14"))
+      assert.truthy(line:find("Layout"))
+    end)
+
+    it("uses corner connector for last item", function()
+      local line = tree.render_sub_issue_line({ number = 16, title = "Done", state = "CLOSED" }, true, 40)
+      -- Should contain the box-drawing corner character (U+2514)
+      assert.truthy(line:find("\xe2\x94\x94"))
+      assert.truthy(line:find("#16"))
+      -- Should contain check mark for closed state
+      assert.truthy(line:find("\xe2\x9c\x93"))
+    end)
+
+    it("uses open circle for open state", function()
+      local line = tree.render_sub_issue_line({ number = 14, title = "Open", state = "OPEN" }, false, 40)
+      assert.truthy(line:find("\xe2\x97\x8b"))
+    end)
+
+    it("truncates long titles with correct display width", function()
+      local long_title = string.rep("A", 100)
+      -- width=30, issue #1: prefix display = 7 + 1 = 8, avail = 22
+      -- Title should be truncated to 21 chars + ellipsis
+      local line = tree.render_sub_issue_line({ number = 1, title = long_title, state = "OPEN" }, true, 30)
+      assert.truthy(line:find("\xe2\x80\xa6")) -- contains ellipsis
+      -- Title portion should fit within available space
+      assert.truthy(line:find("#1"))
+    end)
+
+    it("handles nil title gracefully", function()
+      local line = tree.render_sub_issue_line({ number = 5, state = "OPEN" }, false, 40)
+      assert.truthy(line:find("#5"))
+    end)
+  end)
+
+  describe("render_loading_line", function()
+    it("contains loading text", function()
+      local line = tree.render_loading_line(40)
+      assert.truthy(line:find("loading"))
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Press Enter on a card with sub-issues to expand them as an indented tree (├/└) below the card
- Navigate sub-issues with j/k, preview pane shows sub-issue content
- Expanded column dynamically widens (1.8x) so sub-issue titles are readable, restores on collapse
- New `tree.lua` module manages expansion state, session-scoped cache, and rendering
- GraphQL `fetch_sub_issues` API works for both labels and project source modes
- Fixes vim.NIL handling for null GraphQL bodies, UTF-8 display width for tree chars, async re-render race protection

## Test plan
- [x] 21 new tests in `test_tree_spec.lua` (state, build_visible_items, render helpers)
- [x] 3 new tests in `test_api_fetch_spec.lua` (fetch_sub_issues parse, empty, error)
- [x] 7 new tests in `test_navigation_spec.lua` (tree entry/exit, move_down/up, column change)
- [x] 9 new tests in `test_board_layout_spec.lua` (compute_column_widths)
- [x] `make check` passes (lint + 418 tests, 0 failures)

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)