### PR TITLE
fix(claude): add missing headless mode flags (Fixes #71)

### DIFF
--- a/lua/okuban/claude.lua
+++ b/lua/okuban/claude.lua
@@ -201,16 +201,27 @@ function M.build_prompt(issue_number, context)
   end
 
   table.insert(parts, "Implement the changes described in this issue. Write tests if appropriate.")
-  table.insert(parts, "When done, commit your changes with a message referencing Fixes #" .. issue_number .. ".")
 
   return table.concat(parts, "\n")
 end
 
+--- Build a system prompt for Claude with workflow rules.
+--- Injected via --append-system-prompt to keep the main prompt focused on issue context.
+---@param issue_number integer
+---@return string
+function M.build_system_prompt(issue_number)
+  return "All commits must include 'Fixes #"
+    .. issue_number
+    .. "' or 'Refs #"
+    .. issue_number
+    .. "' in the message. Follow the project's CLAUDE.md conventions."
+end
+
 --- Build the claude CLI command arguments.
 ---@param prompt string
----@param wt_path string Worktree path (used as cwd, not in command)
+---@param issue_number integer Issue number for system prompt
 ---@return string[]
-function M.build_command(prompt, wt_path) -- luacheck: no unused args
+function M.build_command(prompt, issue_number)
   local cfg = config.get().claude
   local cmd = {
     "claude",
@@ -218,11 +229,26 @@ function M.build_command(prompt, wt_path) -- luacheck: no unused args
     prompt,
     "--output-format",
     "stream-json",
+    "--dangerously-skip-permissions",
+    "--max-turns",
+    tostring(cfg.max_turns),
     "--max-budget-usd",
     tostring(cfg.max_budget_usd),
   }
 
-  -- Add allowed tools
+  -- Model override
+  if cfg.model then
+    table.insert(cmd, "--model")
+    table.insert(cmd, cfg.model)
+  end
+
+  -- System prompt with commit conventions
+  if issue_number then
+    table.insert(cmd, "--append-system-prompt")
+    table.insert(cmd, M.build_system_prompt(issue_number))
+  end
+
+  -- Allowed tools
   if cfg.allowed_tools and #cfg.allowed_tools > 0 then
     for _, tool in ipairs(cfg.allowed_tools) do
       table.insert(cmd, "--allowedTools")
@@ -341,7 +367,7 @@ function M.launch(issue, callback)
         end
 
         local prompt = M.build_prompt(issue_number, context)
-        local cmd = M.build_command(prompt, wt_path)
+        local cmd = M.build_command(prompt, issue_number)
 
         -- Launch via jobstart for streaming stdout
         -- jobstart on_stdout receives data as a list of lines split by newlines.

--- a/lua/okuban/config.lua
+++ b/lua/okuban/config.lua
@@ -24,6 +24,7 @@ local M = {}
 ---@field enabled boolean
 ---@field max_budget_usd number
 ---@field max_turns integer
+---@field model string|nil Override Claude model (e.g. "sonnet", "opus")
 ---@field allowed_tools string[]
 ---@field worktree_base_dir string|nil
 ---@field auto_push boolean
@@ -114,6 +115,7 @@ local defaults = {
     enabled = true,
     max_budget_usd = 5.00,
     max_turns = 30,
+    model = nil,
     allowed_tools = {
       "Bash(git:*)",
       "Bash(gh:*)",

--- a/tests/test_claude_spec.lua
+++ b/tests/test_claude_spec.lua
@@ -41,6 +41,11 @@ describe("okuban.claude", function()
       assert.are.equal(5.00, cfg.max_budget_usd)
     end)
 
+    it("has model as nil by default", function()
+      local cfg = config.get().claude
+      assert.is_nil(cfg.model)
+    end)
+
     it("allows overriding allowed_tools via setup", function()
       config.setup({ claude = { allowed_tools = { "Read", "Write" } } })
       local cfg = config.get().claude
@@ -180,39 +185,60 @@ describe("okuban.claude", function()
   end)
 
   describe("build_command", function()
+    --- Helper to find a flag and its value in a command table.
+    local function find_flag(cmd, flag, expected_value)
+      for i, v in ipairs(cmd) do
+        if v == flag then
+          if expected_value == nil then
+            return true
+          end
+          return cmd[i + 1] == expected_value
+        end
+      end
+      return false
+    end
+
     it("includes -p flag with prompt", function()
-      local cmd = claude.build_command("test prompt", "/tmp/wt")
+      local cmd = claude.build_command("test prompt", 42)
       assert.are.equal("claude", cmd[1])
       assert.are.equal("-p", cmd[2])
       assert.are.equal("test prompt", cmd[3])
     end)
 
     it("includes --output-format stream-json", function()
-      local cmd = claude.build_command("prompt", "/tmp/wt")
-      local found = false
-      for i, v in ipairs(cmd) do
-        if v == "--output-format" and cmd[i + 1] == "stream-json" then
-          found = true
-          break
-        end
-      end
-      assert.is_true(found, "expected --output-format stream-json in command")
+      local cmd = claude.build_command("prompt", 42)
+      assert.is_true(find_flag(cmd, "--output-format", "stream-json"), "expected --output-format stream-json")
+    end)
+
+    it("includes --dangerously-skip-permissions", function()
+      local cmd = claude.build_command("prompt", 42)
+      assert.is_true(find_flag(cmd, "--dangerously-skip-permissions"), "expected --dangerously-skip-permissions")
+    end)
+
+    it("includes --max-turns from config", function()
+      local cmd = claude.build_command("prompt", 42)
+      assert.is_true(find_flag(cmd, "--max-turns", "30"), "expected --max-turns 30")
     end)
 
     it("includes --max-budget-usd from config", function()
-      local cmd = claude.build_command("prompt", "/tmp/wt")
+      local cmd = claude.build_command("prompt", 42)
+      assert.is_true(find_flag(cmd, "--max-budget-usd", "5"), "expected --max-budget-usd 5")
+    end)
+
+    it("includes --append-system-prompt with issue reference", function()
+      local cmd = claude.build_command("prompt", 42)
       local found = false
       for i, v in ipairs(cmd) do
-        if v == "--max-budget-usd" and cmd[i + 1] == "5" then
+        if v == "--append-system-prompt" and cmd[i + 1] and cmd[i + 1]:find("Fixes #42") then
           found = true
           break
         end
       end
-      assert.is_true(found, "expected --max-budget-usd 5 in command")
+      assert.is_true(found, "expected --append-system-prompt with Fixes #42")
     end)
 
     it("includes --allowedTools for each configured tool", function()
-      local cmd = claude.build_command("prompt", "/tmp/wt")
+      local cmd = claude.build_command("prompt", 42)
       local tool_count = 0
       for _, v in ipairs(cmd) do
         if v == "--allowedTools" then
@@ -225,15 +251,19 @@ describe("okuban.claude", function()
 
     it("respects custom max_budget_usd", function()
       config.setup({ claude = { max_budget_usd = 10.50 } })
-      local cmd = claude.build_command("prompt", "/tmp/wt")
-      local found = false
-      for i, v in ipairs(cmd) do
-        if v == "--max-budget-usd" and cmd[i + 1] == "10.5" then
-          found = true
-          break
-        end
-      end
-      assert.is_true(found, "expected --max-budget-usd 10.5 in command")
+      local cmd = claude.build_command("prompt", 42)
+      assert.is_true(find_flag(cmd, "--max-budget-usd", "10.5"), "expected --max-budget-usd 10.5")
+    end)
+
+    it("includes --model when configured", function()
+      config.setup({ claude = { model = "sonnet" } })
+      local cmd = claude.build_command("prompt", 42)
+      assert.is_true(find_flag(cmd, "--model", "sonnet"), "expected --model sonnet")
+    end)
+
+    it("omits --model when not configured", function()
+      local cmd = claude.build_command("prompt", 42)
+      assert.is_false(find_flag(cmd, "--model"), "expected no --model flag")
     end)
   end)
 
@@ -283,9 +313,26 @@ describe("okuban.claude", function()
       assert.is_truthy(prompt:find("Comment 8"))
     end)
 
-    it("includes commit instruction with issue reference", function()
+    it("does not include commit instructions (moved to system prompt)", function()
       local prompt = claude.build_prompt(42, { title = "T" })
-      assert.is_truthy(prompt:find("Fixes #42"))
+      assert.is_falsy(prompt:find("commit"))
+    end)
+  end)
+
+  describe("build_system_prompt", function()
+    it("includes Fixes reference for issue number", function()
+      local sp = claude.build_system_prompt(42)
+      assert.is_truthy(sp:find("Fixes #42"))
+    end)
+
+    it("includes Refs reference for issue number", function()
+      local sp = claude.build_system_prompt(42)
+      assert.is_truthy(sp:find("Refs #42"))
+    end)
+
+    it("mentions CLAUDE.md conventions", function()
+      local sp = claude.build_system_prompt(1)
+      assert.is_truthy(sp:find("CLAUDE.md"))
     end)
   end)
 


### PR DESCRIPTION
## Summary
- Add `--dangerously-skip-permissions` to `build_command()` — required for non-interactive sessions
- Add `--max-turns` from config (default 30) — was configured but never passed to CLI
- Add `--model` override support (optional, nil by default)
- Add `--append-system-prompt` with commit conventions via new `build_system_prompt()`
- Move commit instruction from `build_prompt()` to system prompt for cleaner separation
- Add `model` field to `OkubanClaudeConfig`

## Test plan
- [x] All 53 claude tests pass (9 new tests added)
- [x] `make check` passes (lint + test)
- [x] Verified `build_command()` output includes all required flags
- [x] Verified `--model` only appears when configured

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)