### PR TITLE
fix(ui): remove noisy auto-focus notification on board open

### DIFF
--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -142,12 +142,7 @@ function M._populate_board(board, data, skip_focus)
       if not issue_number or not board:is_open() or not board.navigation then
         return
       end
-      local found = board.navigation:focus_issue(issue_number)
-      if found then
-        local issue = board.navigation:get_selected_issue()
-        local title = issue and issue.title or ""
-        utils.notify("Focused on #" .. issue_number .. ": " .. title)
-      end
+      board.navigation:focus_issue(issue_number)
     end)
   end
 end


### PR DESCRIPTION
## Summary
- Removes the `Focused on #N: <title>` notification that fires on every board open
- The cursor silently moves to the detected issue — no "Press ENTER to continue" prompt
- The `g` keymap still shows the notification for explicit user-initiated focus

Refs #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)