### PR TITLE
feat(tmux): pane splitting for Claude sessions with auto-detect launch mode

### DIFF
--- a/lua/okuban/claude.lua
+++ b/lua/okuban/claude.lua
@@ -69,7 +69,6 @@ function M.find_existing_worktree(issue_number)
       return wt_path
     end
   end
-
   return nil
 end
 function M.create_worktree(issue_number, callback)
@@ -78,15 +77,12 @@ function M.create_worktree(issue_number, callback)
     callback(false, nil, err)
     return
   end
-
   local existing = M.find_existing_worktree(issue_number)
   if existing then
     callback(true, existing, nil)
     return
   end
-
   local branch = "feat/issue-" .. issue_number .. "-claude"
-
   vim.system({ "git", "worktree", "add", "-b", branch, wt_path }, { text = true }, function(result)
     vim.schedule(function()
       if result.code == 0 then
@@ -138,7 +134,6 @@ function M.build_prompt(issue_number, context)
     table.insert(parts, context.body)
     table.insert(parts, "")
   end
-
   if context.labels and #context.labels > 0 then
     local label_names = {}
     for _, lbl in ipairs(context.labels) do
@@ -147,7 +142,6 @@ function M.build_prompt(issue_number, context)
     table.insert(parts, "Labels: " .. table.concat(label_names, ", "))
     table.insert(parts, "")
   end
-
   if context.comments and #context.comments > 0 then
     table.insert(parts, "## Recent Comments")
     local max_comments = math.min(5, #context.comments)
@@ -160,9 +154,7 @@ function M.build_prompt(issue_number, context)
     end
     table.insert(parts, "")
   end
-
   table.insert(parts, "Implement the changes described in this issue. Write tests if appropriate.")
-
   return table.concat(parts, "\n")
 end
 function M.build_system_prompt(issue_number)
@@ -312,6 +304,9 @@ function M.launch(issue, callback)
         local launch_mode = cfg.launch_mode
         if cfg.agent_teams and cfg.agent_teams.enabled then
           launch_mode = "tmux"
+        elseif launch_mode == "auto" then
+          local tmux = require("okuban.tmux")
+          launch_mode = tmux.is_available() and "tmux" or "headless"
         end
 
         if launch_mode == "tmux" then
@@ -398,21 +393,23 @@ function M._launch_tmux(issue_number, headless_cmd, wt_path, stop, callback)
 
   local prompt = headless_cmd[3]
   local tmux_cmd = M.build_command(prompt, issue_number, { stream_json = false })
-
-  local sentinel = tmux.launch_window({
+  local split_cfg = config.get().claude.tmux_split or {}
+  local sentinel, pane_id, pane_err = tmux.launch_pane({
     name = "claude-#" .. issue_number,
     cwd = wt_path,
     cmd = tmux_cmd,
     env = M.build_env(),
+    issue_number = issue_number,
+    direction = split_cfg.direction,
+    size = split_cfg.size,
+    target = split_cfg.target,
   })
-
   if not sentinel then
     active_sessions[issue_number] = nil
-    stop("Failed to launch tmux window")
-    callback(false, "Failed to launch tmux window")
+    stop(pane_err or "Failed to launch tmux pane")
+    callback(false, pane_err or "Failed to launch tmux pane")
     return
   end
-
   active_sessions[issue_number] = {
     job_id = nil,
     session_id = nil,
@@ -423,6 +420,7 @@ function M._launch_tmux(issue_number, headless_cmd, wt_path, stop, callback)
     num_turns = nil,
     started_at = os.time(),
     sentinel_path = sentinel,
+    pane_id = pane_id,
   }
 
   tmux.poll_sentinel(sentinel, 2000, function(exit_code)
@@ -477,7 +475,8 @@ function M.resume(issue, callback)
     return
   end
 
-  local is_tmux = config.get().claude.launch_mode == "tmux"
+  local mode = config.get().claude.launch_mode
+  local is_tmux = mode == "tmux" or (mode == "auto" and require("okuban.tmux").is_available())
   local cmd = M.build_resume_command(session.session_id, { stream_json = not is_tmux })
   local noop_stop = function(msg)
     if msg then

--- a/lua/okuban/config.lua
+++ b/lua/okuban/config.lua
@@ -20,6 +20,11 @@ local M = {}
 ---@field refresh string
 ---@field help string
 
+---@class OkubanTmuxSplitConfig
+---@field target "auto"|"self"|"other" Which pane to split (default: "auto")
+---@field direction "h"|"v" Split direction: h=side-by-side, v=top-bottom (default: "h")
+---@field size string|nil Size for new pane (e.g., "50%"), nil=tmux default
+
 ---@class OkubanAgentTeamsConfig
 ---@field enabled boolean EXPERIMENTAL: Enable agent teams (default: false)
 ---@field teammate_mode "tmux"|"auto" Teammate mode (default: "tmux")
@@ -29,12 +34,13 @@ local M = {}
 ---@field max_budget_usd number
 ---@field max_turns integer
 ---@field model string|nil Override Claude model (e.g. "sonnet", "opus")
----@field launch_mode "headless"|"tmux" Launch mode: "headless" (jobstart) or "tmux" (new window)
+---@field launch_mode "auto"|"headless"|"tmux" Launch mode: "auto" (tmux if available), "headless", or "tmux"
 ---@field allowed_tools string[]
 ---@field worktree_base_dir string|nil
 ---@field auto_push boolean
 ---@field auto_pr boolean
 ---@field agent_teams OkubanAgentTeamsConfig
+---@field tmux_split OkubanTmuxSplitConfig
 
 ---@class OkubanProjectConfig
 ---@field number integer|nil Project number (nil = show picker on first :Okuban)
@@ -122,7 +128,7 @@ local defaults = {
     max_budget_usd = 5.00,
     max_turns = 30,
     model = nil,
-    launch_mode = "headless",
+    launch_mode = "auto",
     allowed_tools = {
       "Bash(git:*)",
       "Bash(gh:*)",
@@ -138,6 +144,11 @@ local defaults = {
     agent_teams = {
       enabled = false,
       teammate_mode = "tmux",
+    },
+    tmux_split = {
+      target = "auto",
+      direction = "h",
+      size = nil,
     },
   },
   triage = {

--- a/lua/okuban/tmux.lua
+++ b/lua/okuban/tmux.lua
@@ -81,4 +81,159 @@ function M.poll_sentinel(sentinel, interval, callback)
   return timer
 end
 
+---@class TmuxPaneInfo
+---@field pane_id string
+---@field command string
+---@field active boolean
+---@field width integer
+---@field okuban_issue string
+
+--- Get the pane ID of the current Neovim instance.
+---@return string|nil pane_id
+function M.get_nvim_pane()
+  local pane = vim.env.TMUX_PANE
+  if not pane or pane == "" then
+    return nil
+  end
+  return pane
+end
+
+--- List all panes in the current tmux window.
+---@return TmuxPaneInfo[]|nil panes, string|nil error
+function M.list_panes()
+  local fmt = "#{pane_id}\t#{pane_current_command}\t#{pane_active}\t#{pane_width}\t#{@okuban_issue}"
+  local result = vim.system({ "tmux", "list-panes", "-F", fmt }, { text = true }):wait()
+  if result.code ~= 0 then
+    return nil, "tmux list-panes failed: " .. (result.stderr or "")
+  end
+  local panes = {}
+  for line in (result.stdout or ""):gmatch("[^\n]+") do
+    local id, cmd, active, width, issue = line:match("^(%%?%d+)\t([^\t]*)\t([^\t]*)\t([^\t]*)\t([^\t]*)$")
+    if id then
+      table.insert(panes, {
+        pane_id = id,
+        command = cmd or "",
+        active = active == "1",
+        width = tonumber(width) or 0,
+        okuban_issue = issue or "",
+      })
+    end
+  end
+  return panes, nil
+end
+
+--- Find the best pane to split for a new Claude session.
+--- "auto": prefer widest non-Neovim pane, fallback to Neovim pane.
+--- "self": always split the Neovim pane.
+--- "other": prefer widest non-Neovim pane, fallback to Neovim pane.
+---@param panes TmuxPaneInfo[]
+---@param nvim_pane_id string
+---@param target "auto"|"self"|"other"|nil
+---@return string pane_id
+function M.find_split_target(panes, nvim_pane_id, target)
+  target = target or "auto"
+  if target == "self" then
+    return nvim_pane_id
+  end
+  -- Find widest non-Neovim pane
+  local best, best_width = nil, -1
+  for _, p in ipairs(panes) do
+    if p.pane_id ~= nvim_pane_id and p.width > best_width then
+      best = p.pane_id
+      best_width = p.width
+    end
+  end
+  return best or nvim_pane_id
+end
+
+--- Check if a pane already exists for a given issue number.
+---@param panes TmuxPaneInfo[]
+---@param issue_number integer
+---@return string|nil pane_id
+function M.find_existing_pane(panes, issue_number)
+  local tag = tostring(issue_number)
+  for _, p in ipairs(panes) do
+    if p.okuban_issue == tag then
+      return p.pane_id
+    end
+  end
+  return nil
+end
+
+--- Tag a pane with an issue number using a custom tmux option.
+---@param pane_id string
+---@param issue_number integer
+---@return boolean ok
+function M.tag_pane(pane_id, issue_number)
+  local result = vim
+    .system({ "tmux", "set-option", "-p", "-t", pane_id, "@okuban_issue", tostring(issue_number) }, { text = true })
+    :wait()
+  return result.code == 0
+end
+
+--- Build a tmux split-window command with sentinel wrapper.
+---@param opts table Split options: target, cwd, cmd, env, direction, size
+---@return string[] tmux_cmd, string sentinel_path
+function M.build_split_command(opts)
+  local parts = {}
+  for _, arg in ipairs(opts.cmd) do
+    table.insert(parts, vim.fn.shellescape(arg))
+  end
+  local inner = table.concat(parts, " ")
+  local sentinel = vim.fn.tempname() .. ".okuban-sentinel"
+  local wrapper = string.format("%s; echo $? > %s", inner, vim.fn.shellescape(sentinel))
+  local direction = opts.direction or "h"
+  local tmux_cmd = { "tmux", "split-window", "-" .. direction, "-d", "-P", "-F", "#{pane_id}", "-t", opts.target }
+  if opts.size then
+    table.insert(tmux_cmd, "-l")
+    table.insert(tmux_cmd, opts.size)
+  end
+  table.insert(tmux_cmd, "-c")
+  table.insert(tmux_cmd, opts.cwd)
+  if opts.env then
+    for k, v in pairs(opts.env) do
+      table.insert(tmux_cmd, "-e")
+      table.insert(tmux_cmd, k .. "=" .. v)
+    end
+  end
+  table.insert(tmux_cmd, wrapper)
+  return tmux_cmd, sentinel
+end
+
+--- Launch a command in a new tmux pane by splitting an existing one.
+---@param opts table Pane opts: name, cwd, cmd, env, issue_number, direction, size, target
+---@return string|nil sentinel_path, string|nil pane_id, string|nil error
+function M.launch_pane(opts)
+  local nvim_pane = M.get_nvim_pane()
+  if not nvim_pane then
+    return nil, nil, "TMUX_PANE not set — cannot determine Neovim pane"
+  end
+  local panes, list_err = M.list_panes()
+  if not panes then
+    return nil, nil, list_err or "Failed to list tmux panes"
+  end
+  local existing = M.find_existing_pane(panes, opts.issue_number)
+  if existing then
+    return nil, nil, "Pane already exists for #" .. opts.issue_number
+  end
+  local split_target = M.find_split_target(panes, nvim_pane, opts.target)
+  local tmux_cmd, sentinel = M.build_split_command({
+    target = split_target,
+    cwd = opts.cwd,
+    cmd = opts.cmd,
+    env = opts.env,
+    direction = opts.direction,
+    size = opts.size,
+  })
+  local result = vim.system(tmux_cmd, { text = true }):wait()
+  if result.code ~= 0 then
+    return nil, nil, "tmux split-window failed: " .. (result.stderr or "")
+  end
+  local new_pane_id = vim.trim(result.stdout or "")
+  if new_pane_id ~= "" then
+    M.tag_pane(new_pane_id, opts.issue_number)
+  end
+  return sentinel, new_pane_id, nil
+end
+
 return M

--- a/tests/test_tmux_spec.lua
+++ b/tests/test_tmux_spec.lua
@@ -1,9 +1,14 @@
 describe("okuban.tmux", function()
   local tmux
+  local helpers = require("tests.helpers")
 
   before_each(function()
     package.loaded["okuban.tmux"] = nil
     tmux = require("okuban.tmux")
+  end)
+
+  after_each(function()
+    helpers.restore_vim_system()
   end)
 
   describe("is_available", function()
@@ -137,6 +142,312 @@ describe("okuban.tmux", function()
       if not timer:is_closing() then
         timer:close()
       end
+    end)
+  end)
+
+  describe("get_nvim_pane", function()
+    it("returns TMUX_PANE when set", function()
+      local orig = vim.env.TMUX_PANE
+      vim.env.TMUX_PANE = "%42"
+      assert.are.equal("%42", tmux.get_nvim_pane())
+      vim.env.TMUX_PANE = orig
+    end)
+
+    it("returns nil when TMUX_PANE is nil", function()
+      local orig = vim.env.TMUX_PANE
+      vim.env.TMUX_PANE = nil
+      assert.is_nil(tmux.get_nvim_pane())
+      vim.env.TMUX_PANE = orig
+    end)
+
+    it("returns nil when TMUX_PANE is empty", function()
+      local orig = vim.env.TMUX_PANE
+      vim.env.TMUX_PANE = ""
+      assert.is_nil(tmux.get_nvim_pane())
+      vim.env.TMUX_PANE = orig
+    end)
+  end)
+
+  describe("list_panes", function()
+    it("parses multi-pane output", function()
+      helpers.mock_vim_system({
+        { code = 0, stdout = "%0\tnvim\t1\t120\t\n%1\tbash\t0\t80\t42\n" },
+      })
+      local panes, err = tmux.list_panes()
+      assert.is_nil(err)
+      assert.are.equal(2, #panes)
+      assert.are.equal("%0", panes[1].pane_id)
+      assert.are.equal("nvim", panes[1].command)
+      assert.is_true(panes[1].active)
+      assert.are.equal(120, panes[1].width)
+      assert.are.equal("", panes[1].okuban_issue)
+      assert.are.equal("%1", panes[2].pane_id)
+      assert.are.equal("bash", panes[2].command)
+      assert.is_false(panes[2].active)
+      assert.are.equal(80, panes[2].width)
+      assert.are.equal("42", panes[2].okuban_issue)
+    end)
+
+    it("parses pane with custom okuban_issue option", function()
+      helpers.mock_vim_system({
+        { code = 0, stdout = "%5\tclaude\t0\t60\t99\n" },
+      })
+      local panes = tmux.list_panes()
+      assert.are.equal(1, #panes)
+      assert.are.equal("99", panes[1].okuban_issue)
+    end)
+
+    it("returns error when tmux command fails", function()
+      helpers.mock_vim_system({
+        { code = 1, stderr = "server not found" },
+      })
+      local panes, err = tmux.list_panes()
+      assert.is_nil(panes)
+      assert.is_truthy(err:find("list%-panes failed"))
+    end)
+
+    it("handles single pane output", function()
+      helpers.mock_vim_system({
+        { code = 0, stdout = "%0\tnvim\t1\t200\t\n" },
+      })
+      local panes = tmux.list_panes()
+      assert.are.equal(1, #panes)
+      assert.are.equal("%0", panes[1].pane_id)
+    end)
+  end)
+
+  describe("find_split_target", function()
+    local panes = {
+      { pane_id = "%0", command = "nvim", active = true, width = 120, okuban_issue = "" },
+      { pane_id = "%1", command = "bash", active = false, width = 80, okuban_issue = "" },
+      { pane_id = "%2", command = "zsh", active = false, width = 100, okuban_issue = "" },
+    }
+
+    it("prefers widest non-nvim pane in auto mode", function()
+      local target = tmux.find_split_target(panes, "%0", "auto")
+      assert.are.equal("%2", target)
+    end)
+
+    it("prefers widest non-nvim pane in other mode", function()
+      local target = tmux.find_split_target(panes, "%0", "other")
+      assert.are.equal("%2", target)
+    end)
+
+    it("returns nvim pane in self mode", function()
+      local target = tmux.find_split_target(panes, "%0", "self")
+      assert.are.equal("%0", target)
+    end)
+
+    it("falls back to nvim pane when it is the only pane", function()
+      local single = {
+        { pane_id = "%0", command = "nvim", active = true, width = 200, okuban_issue = "" },
+      }
+      local target = tmux.find_split_target(single, "%0", "auto")
+      assert.are.equal("%0", target)
+    end)
+  end)
+
+  describe("find_existing_pane", function()
+    it("returns pane_id when issue tag matches", function()
+      local panes = {
+        { pane_id = "%0", okuban_issue = "" },
+        { pane_id = "%1", okuban_issue = "42" },
+      }
+      assert.are.equal("%1", tmux.find_existing_pane(panes, 42))
+    end)
+
+    it("returns nil when no pane matches", function()
+      local panes = {
+        { pane_id = "%0", okuban_issue = "" },
+        { pane_id = "%1", okuban_issue = "99" },
+      }
+      assert.is_nil(tmux.find_existing_pane(panes, 42))
+    end)
+
+    it("returns nil for empty pane list", function()
+      assert.is_nil(tmux.find_existing_pane({}, 42))
+    end)
+  end)
+
+  describe("tag_pane", function()
+    it("returns true on success", function()
+      local calls = helpers.mock_vim_system({
+        { code = 0 },
+      })
+      assert.is_true(tmux.tag_pane("%5", 42))
+      assert.are.equal("tmux", calls[1].cmd[1])
+      assert.are.equal("set-option", calls[1].cmd[2])
+      assert.are.equal("-p", calls[1].cmd[3])
+      assert.are.equal("-t", calls[1].cmd[4])
+      assert.are.equal("%5", calls[1].cmd[5])
+      assert.are.equal("@okuban_issue", calls[1].cmd[6])
+      assert.are.equal("42", calls[1].cmd[7])
+    end)
+
+    it("returns false on failure", function()
+      helpers.mock_vim_system({
+        { code = 1, stderr = "no such pane" },
+      })
+      assert.is_false(tmux.tag_pane("%99", 42))
+    end)
+  end)
+
+  describe("build_split_command", function()
+    it("builds split-window command with correct structure", function()
+      local cmd, sentinel = tmux.build_split_command({
+        target = "%0",
+        cwd = "/tmp/work",
+        cmd = { "echo", "hello" },
+      })
+      assert.are.equal("tmux", cmd[1])
+      assert.are.equal("split-window", cmd[2])
+      assert.are.equal("-h", cmd[3])
+      assert.are.equal("-d", cmd[4])
+      assert.are.equal("-P", cmd[5])
+      assert.are.equal("-F", cmd[6])
+      assert.are.equal("#{pane_id}", cmd[7])
+      assert.are.equal("-t", cmd[8])
+      assert.are.equal("%0", cmd[9])
+      assert.is_truthy(sentinel:find("okuban%-sentinel"))
+    end)
+
+    it("uses specified target pane", function()
+      local cmd = tmux.build_split_command({
+        target = "%5",
+        cwd = "/tmp",
+        cmd = { "echo" },
+      })
+      assert.are.equal("%5", cmd[9])
+    end)
+
+    it("includes size when specified", function()
+      local cmd = tmux.build_split_command({
+        target = "%0",
+        cwd = "/tmp",
+        cmd = { "echo" },
+        size = "50%",
+      })
+      local found_size = false
+      for i, v in ipairs(cmd) do
+        if v == "-l" and cmd[i + 1] == "50%" then
+          found_size = true
+        end
+      end
+      assert.is_true(found_size, "expected -l 50% in command")
+    end)
+
+    it("includes environment variables", function()
+      local cmd = tmux.build_split_command({
+        target = "%0",
+        cwd = "/tmp",
+        cmd = { "echo" },
+        env = { FOO = "bar" },
+      })
+      local found_env = false
+      for i, v in ipairs(cmd) do
+        if v == "-e" and cmd[i + 1] and cmd[i + 1]:find("FOO=bar") then
+          found_env = true
+        end
+      end
+      assert.is_true(found_env, "expected -e FOO=bar in command")
+    end)
+  end)
+
+  describe("launch_pane", function()
+    it("orchestrates full flow successfully", function()
+      local orig = vim.env.TMUX_PANE
+      vim.env.TMUX_PANE = "%0"
+      helpers.mock_vim_system({
+        -- list_panes
+        { code = 0, stdout = "%0\tnvim\t1\t120\t\n%1\tbash\t0\t80\t\n" },
+        -- split-window
+        { code = 0, stdout = "%3\n" },
+        -- tag_pane
+        { code = 0 },
+      })
+      local sentinel, pane_id, err = tmux.launch_pane({
+        name = "claude-#42",
+        cwd = "/tmp/work",
+        cmd = { "claude", "-p", "test" },
+        issue_number = 42,
+      })
+      assert.is_truthy(sentinel)
+      assert.are.equal("%3", pane_id)
+      assert.is_nil(err)
+      vim.env.TMUX_PANE = orig
+    end)
+
+    it("returns error when pane already exists for issue", function()
+      local orig = vim.env.TMUX_PANE
+      vim.env.TMUX_PANE = "%0"
+      helpers.mock_vim_system({
+        -- list_panes: pane %1 already tagged with issue 42
+        { code = 0, stdout = "%0\tnvim\t1\t120\t\n%1\tclaude\t0\t80\t42\n" },
+      })
+      local sentinel, pane_id, err = tmux.launch_pane({
+        name = "claude-#42",
+        cwd = "/tmp/work",
+        cmd = { "claude" },
+        issue_number = 42,
+      })
+      assert.is_nil(sentinel)
+      assert.is_nil(pane_id)
+      assert.is_truthy(err:find("already exists"))
+      vim.env.TMUX_PANE = orig
+    end)
+
+    it("returns error when TMUX_PANE is not set", function()
+      local orig = vim.env.TMUX_PANE
+      vim.env.TMUX_PANE = nil
+      local sentinel, pane_id, err = tmux.launch_pane({
+        name = "claude-#42",
+        cwd = "/tmp/work",
+        cmd = { "claude" },
+        issue_number = 42,
+      })
+      assert.is_nil(sentinel)
+      assert.is_nil(pane_id)
+      assert.is_truthy(err:find("TMUX_PANE"))
+      vim.env.TMUX_PANE = orig
+    end)
+
+    it("returns error when list-panes fails", function()
+      local orig = vim.env.TMUX_PANE
+      vim.env.TMUX_PANE = "%0"
+      helpers.mock_vim_system({
+        { code = 1, stderr = "server exited" },
+      })
+      local sentinel, pane_id, err = tmux.launch_pane({
+        name = "claude-#42",
+        cwd = "/tmp/work",
+        cmd = { "claude" },
+        issue_number = 42,
+      })
+      assert.is_nil(sentinel)
+      assert.is_nil(pane_id)
+      assert.is_truthy(err:find("list%-panes"))
+      vim.env.TMUX_PANE = orig
+    end)
+
+    it("returns error when split-window fails", function()
+      local orig = vim.env.TMUX_PANE
+      vim.env.TMUX_PANE = "%0"
+      helpers.mock_vim_system({
+        -- list_panes
+        { code = 0, stdout = "%0\tnvim\t1\t120\t\n" },
+        -- split-window fails (pane too small)
+        { code = 1, stderr = "pane too small" },
+      })
+      local sentinel, pane_id, err = tmux.launch_pane({
+        name = "claude-#42",
+        cwd = "/tmp/work",
+        cmd = { "claude" },
+        issue_number = 42,
+      })
+      assert.is_nil(sentinel)
+      assert.is_nil(pane_id)
+      assert.is_truthy(err:find("split%-window failed"))
+      vim.env.TMUX_PANE = orig
     end)
   end)
 end)


### PR DESCRIPTION
## Summary
- Replace `tmux new-window` with `tmux split-window` so Claude sessions appear alongside the user's panes — no window switching needed
- Add `"auto"` launch mode (new default): uses tmux pane splitting when available, falls back to headless otherwise
- Add `tmux_split` config options: `target` ("auto"/"self"/"other"), `direction` ("h"/"v"), `size`
- 25 new tests covering all pane-management functions

Fixes #89

## Test plan
- [x] `make check` passes (StyLua + Luacheck + 35 tmux tests + all other suites)
- [ ] Manual: In tmux with `[Neovim | Claude Code]` → press `x` on card → Claude pane splits adjacent
- [ ] Manual: Single pane `[Neovim]` → press `x` → Neovim pane splits, Claude appears alongside
- [ ] Manual: Same issue twice → "Pane already exists" notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)