### PR TITLE
test(claude): add immediate-exit integration test for headless race condition

### DIFF
--- a/tests/test_claude_spec.lua
+++ b/tests/test_claude_spec.lua
@@ -792,5 +792,48 @@ describe("okuban.claude", function()
 
       assert.are.equal("failed", session.status)
     end)
+
+    it("immediate process exit transitions session to failed, not stuck at running", function()
+      -- Integration test: jobstart fires on_exit immediately (process exits instantly).
+      -- Before the fix, on_exit would see status="initializing" and ignore it,
+      -- then a new object with status="running" would overwrite — stuck forever.
+      -- After the fix, session is created before jobstart and on_exit captures it.
+      local orig_jobstart = vim.fn.jobstart
+      local captured_on_exit = nil
+      vim.fn.jobstart = function(_, opts)
+        -- Capture on_exit and invoke it immediately (simulating instant process death)
+        captured_on_exit = opts.on_exit
+        local fake_job_id = 999
+        -- Fire on_exit synchronously before jobstart returns
+        if captured_on_exit then
+          captured_on_exit(fake_job_id, 1, "exit")
+        end
+        return fake_job_id
+      end
+
+      local orig_exec = vim.fn.executable
+      vim.fn.executable = function(name)
+        if name == "claude" then
+          return 1
+        end
+        return orig_exec(name)
+      end
+      claude._reset()
+
+      claude._launch_headless(42, { "claude", "-p", "test" }, "/tmp/wt", function() end, function() end)
+
+      -- Let vim.schedule callbacks fire
+      vim.wait(500, function()
+        local s = claude.get_session(42)
+        return s and s.status == "failed"
+      end)
+
+      local session = claude.get_session(42)
+      assert.is_not_nil(session)
+      assert.are.equal("failed", session.status)
+
+      vim.fn.jobstart = orig_jobstart
+      vim.fn.executable = orig_exec
+    end)
   end)
 end)


### PR DESCRIPTION
## Summary
- Add integration test that simulates a Claude process exiting instantly during `_launch_headless`
- Verifies the session transitions to `"failed"` instead of getting stuck at `"running"`
- Completes the final acceptance criterion from #88

All 5 criteria from #88 are now covered:
1. Race condition fix (session created before jobstart) — `claude.lua:325-335`
2. `on_exit` handles all non-terminal statuses — `claude.lua:371`
3. Board refresh detects stale sessions — `claude.lua:493-505`, `board.lua:539, 692`
4. Initializing badge rendering — `card.lua:177-178, 312-313`
5. Immediate-exit integration test — this PR

Fixes #88

## Test plan
- [x] `make check` passes (68 claude tests, 0 failures across all suites)
- [x] New test specifically validates immediate-exit scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)