### PR TITLE
fix(claude): use launcher scripts for tmux sessions and prevent timer GC

### DIFF
--- a/lua/okuban/claude.lua
+++ b/lua/okuban/claude.lua
@@ -183,22 +183,18 @@ function M.build_command(prompt, issue_number, opts)
     table.insert(cmd, "--output-format")
     table.insert(cmd, "stream-json")
   end
-
   if cfg.model then
     table.insert(cmd, "--model")
     table.insert(cmd, cfg.model)
   end
-
   if issue_number then
     table.insert(cmd, "--append-system-prompt")
     table.insert(cmd, M.build_system_prompt(issue_number))
   end
-
   if cfg.agent_teams and cfg.agent_teams.enabled then
     table.insert(cmd, "--teammate-mode")
     table.insert(cmd, cfg.agent_teams.teammate_mode or "tmux")
   end
-
   if cfg.allowed_tools and #cfg.allowed_tools > 0 then
     for _, tool in ipairs(cfg.allowed_tools) do
       table.insert(cmd, "--allowedTools")
@@ -226,7 +222,6 @@ local function handle_event(issue_number, event)
     if not session then
       return
     end
-
     if event.type == "system" and event.subtype == "init" then
       session.session_id = event.session_id
     elseif event.type == "assistant" then
@@ -240,17 +235,14 @@ local function handle_event(issue_number, event)
         session.status = "completed"
       end
 
-      local cost_str = session.cost_usd and string.format("$%.2f", session.cost_usd) or "unknown cost"
-      local turns_str = session.num_turns and (session.num_turns .. " turns") or ""
-      utils.notify(
-        string.format(
-          "Claude finished #%d (%s%s%s)",
-          issue_number,
-          session.status,
-          cost_str ~= "unknown cost" and (", " .. cost_str) or "",
-          turns_str ~= "" and (", " .. turns_str) or ""
-        )
-      )
+      local parts = { session.status }
+      if session.cost_usd then
+        table.insert(parts, string.format("$%.2f", session.cost_usd))
+      end
+      if session.num_turns then
+        table.insert(parts, session.num_turns .. " turns")
+      end
+      utils.notify(string.format("Claude finished #%d (%s)", issue_number, table.concat(parts, ", ")))
     end
   end)
 end
@@ -261,17 +253,14 @@ function M.launch(issue, callback)
     callback(false, "claude CLI not found — install it to use autonomous coding")
     return
   end
-
   local existing = active_sessions[issue_number]
   if existing and (existing.status == "running" or existing.status == "initializing") then
     utils.notify("Claude is already working on #" .. issue_number)
     callback(false, "Session already running")
     return
   end
-
   active_sessions[issue_number] = { status = "initializing" }
   local stop = utils.spinner_start("Launching Claude for #" .. issue_number .. "...")
-
   M.check_auth(function(auth_ok, auth_err)
     if not auth_ok then
       active_sessions[issue_number] = nil
@@ -319,9 +308,7 @@ function M.launch(issue, callback)
   end)
 end
 function M._launch_headless(issue_number, cmd, wt_path, stop, callback)
-  -- Create session object BEFORE jobstart to avoid race condition:
-  -- on_exit can fire before post-jobstart code runs if the process exits immediately.
-  -- By capturing `session` in the closures, we guarantee they update the same object.
+  -- Session object created BEFORE jobstart to avoid race condition (#88)
   local session = {
     job_id = nil,
     session_id = nil,
@@ -367,7 +354,6 @@ function M._launch_headless(issue_number, cmd, wt_path, stop, callback)
     end,
     on_exit = function(_, exit_code, _)
       vim.schedule(function()
-        -- Handle any non-terminal status (running, initializing, etc.)
         if session.status ~= "completed" and session.status ~= "failed" then
           session.status = (exit_code == 0) and "completed" or "failed"
           utils.notify(string.format("Claude finished #%d (%s, exit %d)", issue_number, session.status, exit_code))
@@ -395,7 +381,6 @@ function M._launch_tmux(issue_number, headless_cmd, wt_path, stop, callback)
     callback(false, "tmux not available")
     return
   end
-
   local prompt = headless_cmd[3]
   local tmux_cmd = M.build_command(prompt, issue_number, { stream_json = false })
   local split_cfg = config.get().claude.tmux_split or {}
@@ -428,10 +413,11 @@ function M._launch_tmux(issue_number, headless_cmd, wt_path, stop, callback)
     pane_id = pane_id,
   }
 
-  tmux.poll_sentinel(sentinel, 2000, function(exit_code)
-    local session = active_sessions[issue_number]
+  local session = active_sessions[issue_number]
+  session.poll_timer = tmux.poll_sentinel(sentinel, 2000, function(exit_code)
     if session then
       session.status = (exit_code == 0) and "completed" or "failed"
+      session.poll_timer = nil
       utils.notify(string.format("Claude finished #%d (%s, exit %d)", issue_number, session.status, exit_code))
     end
   end)
@@ -479,7 +465,6 @@ function M.resume(issue, callback)
     callback(false, "No worktree path for session #" .. issue_number)
     return
   end
-
   local mode = config.get().claude.launch_mode
   local is_tmux = mode == "tmux" or (mode == "auto" and require("okuban.tmux").is_available())
   local cmd = M.build_resume_command(session.session_id, { stream_json = not is_tmux })
@@ -490,14 +475,12 @@ function M.resume(issue, callback)
   end
   M._launch_headless(issue_number, cmd, wt_path, noop_stop, callback)
 end
---- Check all headless sessions for liveness and correct stale "running" status.
---- Uses vim.fn.jobwait() with 0 timeout (non-blocking) to detect dead jobs.
+--- Check headless sessions for liveness; correct stale "running" status.
 function M.verify_sessions()
   for _, session in pairs(active_sessions) do
     if session.status == "running" and session.job_id then
       local result = vim.fn.jobwait({ session.job_id }, 0)
       if result[1] ~= -1 then
-        -- Job has exited but on_exit didn't update status (or was missed)
         session.status = "failed"
       end
     end

--- a/lua/okuban/tmux.lua
+++ b/lua/okuban/tmux.lua
@@ -11,32 +11,16 @@ end
 ---@param opts { name: string, cwd: string, cmd: string[], env: table<string,string>|nil }
 ---@return string[] tmux_cmd, string sentinel_path
 function M.build_launch_command(opts)
-  -- Build the inner command string (shell-escaped)
-  local parts = {}
-  for _, arg in ipairs(opts.cmd) do
-    table.insert(parts, vim.fn.shellescape(arg))
-  end
-  local inner = table.concat(parts, " ")
-
-  -- Sentinel file for completion detection
   local sentinel = vim.fn.tempname() .. ".okuban-sentinel"
-
-  -- Wrapper: run command, capture exit code, write to sentinel
-  local wrapper = string.format("%s; echo $? > %s", inner, vim.fn.shellescape(sentinel))
-
-  -- Build tmux command
+  local script = M.write_launcher_script(opts.cmd, sentinel)
   local tmux_cmd = { "tmux", "new-window", "-n", opts.name, "-c", opts.cwd }
-
-  -- Add environment variables
   if opts.env then
     for k, v in pairs(opts.env) do
       table.insert(tmux_cmd, "-e")
       table.insert(tmux_cmd, k .. "=" .. v)
     end
   end
-
-  table.insert(tmux_cmd, wrapper)
-
+  table.insert(tmux_cmd, script)
   return tmux_cmd, sentinel
 end
 
@@ -171,17 +155,39 @@ function M.tag_pane(pane_id, issue_number)
   return result.code == 0
 end
 
+--- Write a launcher script that runs the command and writes exit code to sentinel.
+--- Using a script file avoids shell quoting issues when passing complex args through tmux.
+---@param cmd string[] Command to run
+---@param sentinel string Path to sentinel file
+---@return string script_path
+function M.write_launcher_script(cmd, sentinel)
+  local script = vim.fn.tempname() .. ".okuban-launcher.sh"
+  local lines = { "#!/bin/sh" }
+  -- Build the command with proper quoting
+  local parts = {}
+  for _, arg in ipairs(cmd) do
+    table.insert(parts, vim.fn.shellescape(arg))
+  end
+  table.insert(lines, table.concat(parts, " "))
+  table.insert(lines, string.format("echo $? > %s", vim.fn.shellescape(sentinel)))
+  -- Clean up the script itself
+  table.insert(lines, string.format("rm -f %s", vim.fn.shellescape(script)))
+  local f = io.open(script, "w")
+  if not f then
+    return script
+  end
+  f:write(table.concat(lines, "\n") .. "\n")
+  f:close()
+  vim.fn.setfperm(script, "rwx------")
+  return script
+end
+
 --- Build a tmux split-window command with sentinel wrapper.
 ---@param opts table Split options: target, cwd, cmd, env, direction, size
 ---@return string[] tmux_cmd, string sentinel_path
 function M.build_split_command(opts)
-  local parts = {}
-  for _, arg in ipairs(opts.cmd) do
-    table.insert(parts, vim.fn.shellescape(arg))
-  end
-  local inner = table.concat(parts, " ")
   local sentinel = vim.fn.tempname() .. ".okuban-sentinel"
-  local wrapper = string.format("%s; echo $? > %s", inner, vim.fn.shellescape(sentinel))
+  local script = M.write_launcher_script(opts.cmd, sentinel)
   local direction = opts.direction or "h"
   local tmux_cmd = { "tmux", "split-window", "-" .. direction, "-d", "-P", "-F", "#{pane_id}", "-t", opts.target }
   if opts.size then
@@ -196,7 +202,7 @@ function M.build_split_command(opts)
       table.insert(tmux_cmd, k .. "=" .. v)
     end
   end
-  table.insert(tmux_cmd, wrapper)
+  table.insert(tmux_cmd, script)
   return tmux_cmd, sentinel
 end
 

--- a/tests/test_tmux_spec.lua
+++ b/tests/test_tmux_spec.lua
@@ -76,16 +76,23 @@ describe("okuban.tmux", function()
       assert.is_truthy(sentinel:match("%.okuban%-sentinel$"))
     end)
 
-    it("wraps command with sentinel write", function()
+    it("uses launcher script with sentinel write", function()
       local cmd = tmux.build_launch_command({
         name = "test",
         cwd = "/tmp",
         cmd = { "claude", "-p", "hello world" },
       })
-      -- Last element should be the wrapper command
-      local wrapper = cmd[#cmd]
-      assert.is_truthy(wrapper:find("echo %$%?"))
-      assert.is_truthy(wrapper:find("claude"))
+      -- Last element should be the script path
+      local script_path = cmd[#cmd]
+      assert.is_truthy(script_path:find("okuban%-launcher%.sh"))
+      -- Script content should have the command and sentinel write
+      local f = io.open(script_path, "r")
+      assert.is_truthy(f)
+      local content = f:read("*a")
+      f:close()
+      os.remove(script_path)
+      assert.is_truthy(content:find("claude"))
+      assert.is_truthy(content:find("echo %$%?"))
     end)
   end)
 
@@ -289,6 +296,34 @@ describe("okuban.tmux", function()
         { code = 1, stderr = "no such pane" },
       })
       assert.is_false(tmux.tag_pane("%99", 42))
+    end)
+  end)
+
+  describe("write_launcher_script", function()
+    it("creates executable script with command and sentinel", function()
+      local sentinel = "/tmp/test-sentinel"
+      local script = tmux.write_launcher_script({ "echo", "hello world" }, sentinel)
+      assert.is_truthy(script:find("okuban%-launcher%.sh"))
+      local f = io.open(script, "r")
+      assert.is_truthy(f)
+      local content = f:read("*a")
+      f:close()
+      os.remove(script)
+      assert.is_truthy(content:find("#!/bin/sh"))
+      assert.is_truthy(content:find("echo"))
+      assert.is_truthy(content:find("hello world"))
+      assert.is_truthy(content:find("echo %$%?"))
+      assert.is_truthy(content:find(sentinel))
+    end)
+
+    it("cleans up the script file after execution", function()
+      local sentinel = "/tmp/test-sentinel"
+      local script = tmux.write_launcher_script({ "echo" }, sentinel)
+      local f = io.open(script, "r")
+      local content = f:read("*a")
+      f:close()
+      os.remove(script)
+      assert.is_truthy(content:find("rm %-f"))
     end)
   end)
 


### PR DESCRIPTION
## Summary

Fixes #95 — Two bugs caused Claude sessions to fail silently when launched via tmux pane splitting:

- **Timer GC**: `poll_sentinel()` timer handle was discarded, allowing Lua GC to stop the sentinel polling. Now stored in `session.poll_timer`.
- **Shell quoting**: Complex prompts with single quotes broke when embedded inline in `tmux split-window` args. Now writes commands to temp launcher scripts (`write_launcher_script()`) that self-delete after execution.

## Changes

- `tmux.lua`: Added `write_launcher_script()`, updated `build_launch_command()` and `build_split_command()` to use launcher scripts
- `claude.lua`: Store `poll_timer` in session object to prevent GC, clear on completion
- `test_tmux_spec.lua`: Added tests for `write_launcher_script`, updated existing build command tests

## Test plan

- [x] `make check` passes (513 tests, 0 failures, lint clean)
- [ ] Manual: Open board → Code with Claude → verify Claude appears and runs in split pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)