### PR TITLE
feat(claude): run Claude interactively in tmux pane with prompt file

### DIFF
--- a/lua/okuban/claude.lua
+++ b/lua/okuban/claude.lua
@@ -164,44 +164,32 @@ function M.build_system_prompt(issue_number)
     .. issue_number
     .. "' in the message. Follow the project's CLAUDE.md conventions."
 end
-function M.build_command(prompt, issue_number, opts)
-  opts = opts or {}
-  local stream_json = opts.stream_json ~= false
-  local cfg = config.get().claude
-  local cmd = {
-    "claude",
-    "-p",
-    prompt,
-    "--dangerously-skip-permissions",
-    "--max-turns",
-    tostring(cfg.max_turns),
-    "--max-budget-usd",
-    tostring(cfg.max_budget_usd),
-  }
-
-  if stream_json then
-    table.insert(cmd, "--output-format")
-    table.insert(cmd, "stream-json")
-  end
+local function append_common_flags(cmd, issue_number, cfg)
+  vim.list_extend(cmd, { "--dangerously-skip-permissions", "--max-turns", tostring(cfg.max_turns) })
+  vim.list_extend(cmd, { "--max-budget-usd", tostring(cfg.max_budget_usd) })
   if cfg.model then
-    table.insert(cmd, "--model")
-    table.insert(cmd, cfg.model)
+    vim.list_extend(cmd, { "--model", cfg.model })
   end
   if issue_number then
-    table.insert(cmd, "--append-system-prompt")
-    table.insert(cmd, M.build_system_prompt(issue_number))
+    vim.list_extend(cmd, { "--append-system-prompt", M.build_system_prompt(issue_number) })
   end
   if cfg.agent_teams and cfg.agent_teams.enabled then
-    table.insert(cmd, "--teammate-mode")
-    table.insert(cmd, cfg.agent_teams.teammate_mode or "tmux")
+    vim.list_extend(cmd, { "--teammate-mode", cfg.agent_teams.teammate_mode or "tmux" })
   end
   if cfg.allowed_tools and #cfg.allowed_tools > 0 then
     for _, tool in ipairs(cfg.allowed_tools) do
-      table.insert(cmd, "--allowedTools")
-      table.insert(cmd, tool)
+      vim.list_extend(cmd, { "--allowedTools", tool })
     end
   end
-
+end
+function M.build_command(prompt, issue_number, opts)
+  opts = opts or {}
+  local cfg = config.get().claude
+  local cmd = { "claude", "-p", prompt }
+  append_common_flags(cmd, issue_number, cfg)
+  if opts.stream_json ~= false then
+    vim.list_extend(cmd, { "--output-format", "stream-json" })
+  end
   return cmd
 end
 function M.parse_stream_event(line)
@@ -381,13 +369,18 @@ function M._launch_tmux(issue_number, headless_cmd, wt_path, stop, callback)
     callback(false, "tmux not available")
     return
   end
+  -- Build interactive command: no -p flag, prompt read from file by launcher
   local prompt = headless_cmd[3]
-  local tmux_cmd = M.build_command(prompt, issue_number, { stream_json = false })
-  local split_cfg = config.get().claude.tmux_split or {}
+  local prompt_file = tmux.write_prompt_file(prompt)
+  local cfg = config.get().claude
+  local tmux_cmd = { "claude" }
+  append_common_flags(tmux_cmd, issue_number, cfg)
+  local split_cfg = cfg.tmux_split or {}
   local sentinel, pane_id, pane_err = tmux.launch_pane({
     name = "claude-#" .. issue_number,
     cwd = wt_path,
     cmd = tmux_cmd,
+    prompt_file = prompt_file,
     env = M.build_env(),
     issue_number = issue_number,
     direction = split_cfg.direction,

--- a/lua/okuban/tmux.lua
+++ b/lua/okuban/tmux.lua
@@ -182,12 +182,64 @@ function M.write_launcher_script(cmd, sentinel)
   return script
 end
 
+--- Write prompt text to a temp file for safe passing to Claude via tmux.
+--- This avoids all shell quoting issues with complex multi-line prompts.
+---@param text string Prompt text
+---@return string path Temp file path
+function M.write_prompt_file(text)
+  local path = vim.fn.tempname() .. ".okuban-prompt"
+  local f = io.open(path, "w")
+  if f then
+    f:write(text)
+    f:close()
+  end
+  return path
+end
+
+--- Write an interactive launcher script that reads prompt from file and runs Claude.
+--- The prompt is read from a file to avoid shell quoting issues. Claude runs interactively
+--- (no -p flag) so the user can see it working and follow up.
+---@param cmd string[] Command flags (e.g., {"claude", "--max-turns", "10"})
+---@param prompt_file string Path to file containing the prompt text
+---@param sentinel string Path to sentinel file for exit code
+---@return string script_path
+function M.write_interactive_launcher(cmd, prompt_file, sentinel)
+  local script = vim.fn.tempname() .. ".okuban-launcher.sh"
+  local lines = { "#!/bin/sh" }
+  -- Read prompt from file (avoids all shell quoting issues)
+  table.insert(lines, string.format("PROMPT=$(cat %s)", vim.fn.shellescape(prompt_file)))
+  table.insert(lines, string.format("rm -f %s", vim.fn.shellescape(prompt_file)))
+  -- Build command: claude "$PROMPT" [flags...]
+  local parts = { vim.fn.shellescape(cmd[1]), '"$PROMPT"' }
+  for i = 2, #cmd do
+    table.insert(parts, vim.fn.shellescape(cmd[i]))
+  end
+  table.insert(lines, table.concat(parts, " "))
+  -- Write exit code to sentinel
+  table.insert(lines, string.format("echo $? > %s", vim.fn.shellescape(sentinel)))
+  -- Clean up script
+  table.insert(lines, string.format("rm -f %s", vim.fn.shellescape(script)))
+  local f = io.open(script, "w")
+  if not f then
+    return script
+  end
+  f:write(table.concat(lines, "\n") .. "\n")
+  f:close()
+  vim.fn.setfperm(script, "rwx------")
+  return script
+end
+
 --- Build a tmux split-window command with sentinel wrapper.
----@param opts table Split options: target, cwd, cmd, env, direction, size
+---@param opts table Split options: target, cwd, cmd, env, direction, size, prompt_file
 ---@return string[] tmux_cmd, string sentinel_path
 function M.build_split_command(opts)
   local sentinel = vim.fn.tempname() .. ".okuban-sentinel"
-  local script = M.write_launcher_script(opts.cmd, sentinel)
+  local script
+  if opts.prompt_file then
+    script = M.write_interactive_launcher(opts.cmd, opts.prompt_file, sentinel)
+  else
+    script = M.write_launcher_script(opts.cmd, sentinel)
+  end
   local direction = opts.direction or "h"
   local tmux_cmd = { "tmux", "split-window", "-" .. direction, "-d", "-P", "-F", "#{pane_id}", "-t", opts.target }
   if opts.size then
@@ -207,7 +259,7 @@ function M.build_split_command(opts)
 end
 
 --- Launch a command in a new tmux pane by splitting an existing one.
----@param opts table Pane opts: name, cwd, cmd, env, issue_number, direction, size, target
+---@param opts table Pane opts: name, cwd, cmd, env, issue_number, direction, size, target, prompt_file
 ---@return string|nil sentinel_path, string|nil pane_id, string|nil error
 function M.launch_pane(opts)
   local nvim_pane = M.get_nvim_pane()
@@ -227,6 +279,7 @@ function M.launch_pane(opts)
     target = split_target,
     cwd = opts.cwd,
     cmd = opts.cmd,
+    prompt_file = opts.prompt_file,
     env = opts.env,
     direction = opts.direction,
     size = opts.size,

--- a/tests/test_tmux_spec.lua
+++ b/tests/test_tmux_spec.lua
@@ -313,7 +313,7 @@ describe("okuban.tmux", function()
       assert.is_truthy(content:find("echo"))
       assert.is_truthy(content:find("hello world"))
       assert.is_truthy(content:find("echo %$%?"))
-      assert.is_truthy(content:find(sentinel))
+      assert.is_truthy(content:find(sentinel, 1, true))
     end)
 
     it("cleans up the script file after execution", function()
@@ -324,6 +324,66 @@ describe("okuban.tmux", function()
       f:close()
       os.remove(script)
       assert.is_truthy(content:find("rm %-f"))
+    end)
+  end)
+
+  describe("write_prompt_file", function()
+    it("writes text to a temp file and returns path", function()
+      local path = tmux.write_prompt_file("Hello, world!")
+      assert.is_truthy(path:find("okuban%-prompt"))
+      local f = io.open(path, "r")
+      assert.is_truthy(f)
+      local content = f:read("*a")
+      f:close()
+      os.remove(path)
+      assert.are.equal("Hello, world!", content)
+    end)
+
+    it("handles multi-line text with special characters", function()
+      local text = "Line 1\nLine 2 with 'quotes' and $vars\nLine 3"
+      local path = tmux.write_prompt_file(text)
+      local f = io.open(path, "r")
+      local content = f:read("*a")
+      f:close()
+      os.remove(path)
+      assert.are.equal(text, content)
+    end)
+  end)
+
+  describe("write_interactive_launcher", function()
+    it("reads prompt from file and passes as positional arg", function()
+      local prompt_file = "/tmp/test-prompt"
+      local sentinel = "/tmp/test-sentinel"
+      local script = tmux.write_interactive_launcher(
+        { "claude", "--max-turns", "10" },
+        prompt_file,
+        sentinel
+      )
+      local f = io.open(script, "r")
+      local content = f:read("*a")
+      f:close()
+      os.remove(script)
+      assert.is_truthy(content:find("#!/bin/sh"))
+      assert.is_truthy(content:find("PROMPT=$(cat", 1, true))
+      assert.is_truthy(content:find(prompt_file, 1, true))
+      assert.is_truthy(content:find('"$PROMPT"', 1, true))
+      assert.is_truthy(content:find("claude"))
+      assert.is_truthy(content:find("echo %$%?"))
+      assert.is_truthy(content:find(sentinel, 1, true))
+    end)
+
+    it("cleans up prompt file and script after execution", function()
+      local prompt_file = "/tmp/test-prompt"
+      local sentinel = "/tmp/test-sentinel"
+      local script = tmux.write_interactive_launcher({ "claude" }, prompt_file, sentinel)
+      local f = io.open(script, "r")
+      local content = f:read("*a")
+      f:close()
+      os.remove(script)
+      -- Should remove prompt file
+      assert.is_truthy(content:find("rm %-f.*" .. prompt_file:gsub("%-", "%%-")))
+      -- Should remove script itself
+      assert.is_truthy(content:find("rm %-f.*okuban%-launcher"))
     end)
   end)
 
@@ -385,6 +445,30 @@ describe("okuban.tmux", function()
         end
       end
       assert.is_true(found_env, "expected -e FOO=bar in command")
+    end)
+
+    it("uses interactive launcher when prompt_file is provided", function()
+      local prompt_file = vim.fn.tempname() .. ".okuban-prompt"
+      local f = io.open(prompt_file, "w")
+      f:write("test prompt")
+      f:close()
+      local cmd, sentinel = tmux.build_split_command({
+        target = "%0",
+        cwd = "/tmp",
+        cmd = { "claude", "--max-turns", "10" },
+        prompt_file = prompt_file,
+      })
+      assert.is_truthy(sentinel)
+      -- Last element should be the interactive launcher script
+      local script_path = cmd[#cmd]
+      assert.is_truthy(script_path:find("okuban%-launcher%.sh"))
+      local sf = io.open(script_path, "r")
+      local content = sf:read("*a")
+      sf:close()
+      os.remove(script_path)
+      os.remove(prompt_file)
+      assert.is_truthy(content:find("PROMPT=$(cat", 1, true))
+      assert.is_truthy(content:find('"$PROMPT"', 1, true))
     end)
   end)
 


### PR DESCRIPTION
## Summary

Fixes #99 — Switches tmux mode from headless (`-p`) to interactive mode so the user sees Claude's full TUI in the split pane.

- Prompt written to temp file, read by launcher script (eliminates all shell quoting issues)
- `write_prompt_file()` and `write_interactive_launcher()` added to `tmux.lua`
- `build_command()` refactored with shared `append_common_flags()` to avoid duplication
- Pane stays open — user can watch Claude work and follow up when done

## Test plan

- [x] `make check` passes (522 tests, 0 failures, lint clean)
- [ ] Manual: Open board → Code with Claude → verify Claude TUI appears in split pane
- [ ] Manual: Claude processes the issue prompt while user watches

🤖 Generated with [Claude Code](https://claude.com/claude-code)