### PR TITLE
feat(ui): auto-move issue to in-progress on Claude launch, fix split direction

### DIFF
--- a/lua/okuban/config.lua
+++ b/lua/okuban/config.lua
@@ -147,7 +147,7 @@ local defaults = {
     },
     tmux_split = {
       target = "auto",
-      direction = "h",
+      direction = "v",
       size = nil,
     },
   },

--- a/lua/okuban/ui/actions.lua
+++ b/lua/okuban/ui/actions.lua
@@ -17,6 +17,30 @@ function M.close()
   actions_buf = nil
 end
 
+--- Auto-move an issue to in-progress when launching Claude.
+--- Finds the current okuban: label and swaps it. Also handles unsorted issues.
+---@param issue table Issue data with labels
+---@param board table Board instance
+function M._auto_move_to_in_progress(issue, board)
+  local target = "okuban:in-progress"
+  local current_label = nil
+  if issue.labels then
+    for _, lbl in ipairs(issue.labels) do
+      if lbl.name:match("^okuban:") then
+        current_label = lbl.name
+        break
+      end
+    end
+  end
+  if current_label == target then
+    return
+  end
+  -- For unsorted issues (no okuban: label), remove is a no-op in gh CLI
+  local from_label = current_label or target
+  local move = require("okuban.ui.move")
+  move.execute_move(issue.number, from_label, target, "In Progress", board)
+end
+
 --- Build the list of action items for an issue.
 ---@param issue table
 ---@param board table Board instance
@@ -159,6 +183,8 @@ function M._build_actions(issue, board)
             label = "Code with Claude",
             callback = function()
               M.close()
+              -- Auto-move to in-progress when launching Claude
+              M._auto_move_to_in_progress(issue, board)
               claude_mod.launch(issue, function(ok, err)
                 if not ok then
                   utils.notify("Failed: " .. (err or "unknown"), vim.log.levels.ERROR)

--- a/tests/test_tmux_spec.lua
+++ b/tests/test_tmux_spec.lua
@@ -354,11 +354,7 @@ describe("okuban.tmux", function()
     it("reads prompt from file and passes as positional arg", function()
       local prompt_file = "/tmp/test-prompt"
       local sentinel = "/tmp/test-sentinel"
-      local script = tmux.write_interactive_launcher(
-        { "claude", "--max-turns", "10" },
-        prompt_file,
-        sentinel
-      )
+      local script = tmux.write_interactive_launcher({ "claude", "--max-turns", "10" }, prompt_file, sentinel)
       local f = io.open(script, "r")
       local content = f:read("*a")
       f:close()


### PR DESCRIPTION
## Summary

Fixes #102 — Two UX improvements:

- **Auto-move to In Progress**: "Code with Claude" action now moves the issue to `okuban:in-progress` before launching Claude, so the board reflects that work is happening
- **Split direction**: Default changed from `"h"` (side-by-side) to `"v"` (top/bottom) for better tmux layout

## Test plan

- [x] `make check` passes (all tests, 0 failures, lint clean)
- [ ] Manual: Trigger "Code with Claude" on a backlog issue → verify it moves to In Progress
- [ ] Manual: Claude pane appears below, not to the side

🤖 Generated with [Claude Code](https://claude.com/claude-code)