### PR TITLE
feat(claude): add explicit rules to autonomous session system prompt

### DIFF
--- a/lua/okuban/claude.lua
+++ b/lua/okuban/claude.lua
@@ -158,11 +158,15 @@ function M.build_prompt(issue_number, context)
   return table.concat(parts, "\n")
 end
 function M.build_system_prompt(issue_number)
-  return "All commits must include 'Fixes #"
+  return "RULES: "
+    .. "1) All commits must include 'Fixes #"
     .. issue_number
     .. "' or 'Refs #"
     .. issue_number
-    .. "' in the message. Follow the project's CLAUDE.md conventions."
+    .. "'. "
+    .. "2) Work on a feature branch, NEVER commit to main. "
+    .. "3) If creating issues, ALWAYS add an okuban: kanban label (okuban:backlog, okuban:todo, etc). "
+    .. "4) Read CLAUDE.md before starting — it has project conventions you MUST follow."
 end
 local function append_common_flags(cmd, issue_number, cfg)
   vim.list_extend(cmd, { "--dangerously-skip-permissions", "--max-turns", tostring(cfg.max_turns) })

--- a/tests/test_claude_spec.lua
+++ b/tests/test_claude_spec.lua
@@ -334,6 +334,16 @@ describe("okuban.claude", function()
       local sp = claude.build_system_prompt(1)
       assert.is_truthy(sp:find("CLAUDE.md"))
     end)
+
+    it("requires kanban labels on new issues", function()
+      local sp = claude.build_system_prompt(10)
+      assert.is_truthy(sp:find("okuban:"))
+    end)
+
+    it("prohibits committing to main", function()
+      local sp = claude.build_system_prompt(10)
+      assert.is_truthy(sp:find("NEVER commit to main"))
+    end)
   end)
 
   describe("session state", function()


### PR DESCRIPTION
## Summary
- Enhanced `build_system_prompt()` with explicit numbered rules instead of vague "follow conventions" directive
- Autonomous Claude sessions now get clear guardrails: commit refs, feature branch requirement, kanban label requirement, CLAUDE.md directive
- Added 2 new tests verifying kanban label and main-branch rules

Fixes #105

## Context
During testing (#97), an autonomous Claude session created issue #101 without any kanban label, violating the project's issue-driven workflow. Root cause: `build_system_prompt()` said "Follow the project's CLAUDE.md conventions" without specifying what those conventions are.

## Test plan
- [x] All 522 tests pass (`make check`)
- [x] Existing `build_system_prompt` tests still pass (Fixes #N, Refs #N, CLAUDE.md references preserved)
- [x] New tests verify kanban label and branch rules are present in the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)