### PR TITLE
feat(claude): add context-gathering instructions to autonomous prompt

### DIFF
--- a/lua/okuban/claude.lua
+++ b/lua/okuban/claude.lua
@@ -154,7 +154,10 @@ function M.build_prompt(issue_number, context)
     end
     table.insert(parts, "")
   end
-  table.insert(parts, "Implement the changes described in this issue. Write tests if appropriate.")
+  table.insert(parts, "## Instructions")
+  table.insert(parts, "1. Read CLAUDE.md and explore the codebase to understand conventions and architecture.")
+  table.insert(parts, "2. If the issue is vague or missing acceptance criteria, state your assumptions before coding.")
+  table.insert(parts, "3. Implement the changes. Write tests if appropriate.")
   return table.concat(parts, "\n")
 end
 function M.build_system_prompt(issue_number)

--- a/tests/test_claude_spec.lua
+++ b/tests/test_claude_spec.lua
@@ -317,6 +317,17 @@ describe("okuban.claude", function()
       local prompt = claude.build_prompt(42, { title = "T" })
       assert.is_falsy(prompt:find("commit"))
     end)
+
+    it("includes instructions to read CLAUDE.md and explore codebase", function()
+      local prompt = claude.build_prompt(1, { title = "T" })
+      assert.is_truthy(prompt:find("CLAUDE.md"))
+      assert.is_truthy(prompt:find("explore"))
+    end)
+
+    it("instructs to state assumptions when issue is vague", function()
+      local prompt = claude.build_prompt(1, { title = "T" })
+      assert.is_truthy(prompt:find("assumptions"))
+    end)
   end)
 
   describe("build_system_prompt", function()


### PR DESCRIPTION
## Summary
- Replaced single "Implement the changes" instruction with structured 3-step workflow
- Autonomous Claude now: (1) reads CLAUDE.md and explores codebase, (2) states assumptions if issue is vague, (3) implements and tests
- Added 2 new tests verifying the instructions include CLAUDE.md reference and assumption-stating guidance

Fixes #107

## Test plan
- [x] All 524 tests pass (`make check`)
- [x] Existing prompt tests still pass (issue number, title, body, labels, comments)
- [x] New tests verify CLAUDE.md and assumptions instructions are present
- [x] `claude.lua` at exactly 500 lines (within budget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)