### PR TITLE
fix(api): increase sub-issue fetch limit from 50 to 100

### DIFF
--- a/lua/okuban/api_labels.lua
+++ b/lua/okuban/api_labels.lua
@@ -353,7 +353,7 @@ function M.fetch_sub_issues(parent_number, callback)
     end
 
     local tmpl = '{ repository(owner: "%s", name: "%s") {'
-      .. " issue(number: %d) { subIssues(first: 50)"
+      .. " issue(number: %d) { subIssues(first: 100)"
       .. " { nodes { number title state body } } } } }"
     local query = string.format(tmpl, owner, name, parent_number)
 


### PR DESCRIPTION
## Summary
- Bumped `subIssues(first: 50)` to `subIssues(first: 100)` in the GraphQL query
- GitHub's API max is 100; their UI caps sub-issues at 50 per parent, so 100 covers everything
- Fixes the issue where open sub-issues were invisible because the first 50 returned were all closed

Refs #111

## Root cause
GitHub's subIssues API returns oldest first by default. For issues with 50+ sub-issues, the `first: 50` limit cut off newer/open sub-issues. The client-side sort (open-first, newest-first from #111) only works if all sub-issues are fetched.

## Test plan
- [x] All 525 tests pass (`make check`)
- [x] Verified via `gh api graphql` that `first: 100` is accepted and `first: 101` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)