### PR TITLE
feat(claude): stagger concurrent session launches to mitigate SQLite contention (Fixes #116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ require("okuban").setup({
     max_turns = 30,             -- max agentic turns per session
     model = nil,                -- override model (e.g. "sonnet", "opus")
     launch_mode = "auto",       -- "auto" | "headless" | "tmux"
+    max_concurrent_sessions = 3, -- max simultaneous Claude sessions
+    launch_stagger_ms = 3000,   -- delay (ms) between consecutive launches
     allowed_tools = {
       "Bash(git:*)",
       "Bash(gh:*)",
@@ -488,6 +490,21 @@ Install Claude Code from https://claude.ai/code. This is optional — the board 
 
 **"tmux not available"**
 Claude defaults to headless mode if you're not inside tmux. To use interactive mode with a visible Claude pane, start Neovim inside a tmux session. You can also force headless mode: `claude = { launch_mode = "headless" }`.
+
+**Claude Code sessions hang or freeze (SQLite contention)**
+This is a known upstream issue in Claude Code. Each `claude` process shares a SQLite database (`~/.claude/__store.db`), and Claude Code currently uses `journal_mode=DELETE` with `busy_timeout=0`, which means concurrent writers can deadlock. This affects any scenario where multiple Claude processes run simultaneously — including okuban-launched sessions alongside an interactive Claude Code session.
+
+**Mitigation:** okuban staggers session launches (3s delay between each) and caps concurrent sessions at 3 by default. You can tune these:
+```lua
+require("okuban").setup({
+  claude = {
+    max_concurrent_sessions = 2,  -- lower if you still see hangs
+    launch_stagger_ms = 5000,     -- increase delay between launches
+  },
+})
+```
+
+**Root cause fix:** This must be addressed by Anthropic — switching Claude Code's SQLite to WAL mode and adding a nonzero `busy_timeout`. Track progress at [anthropics/claude-code#14124](https://github.com/anthropics/claude-code/issues/14124).
 
 **Board looks wrong after resizing the terminal**
 The board automatically repositions on `VimResized`, but if something looks off, press `r` to refresh or reopen with `:Okuban`.

--- a/lua/okuban/claude.lua
+++ b/lua/okuban/claude.lua
@@ -5,10 +5,50 @@ local M = {}
 
 local active_sessions = {} ---@type table<integer, table>
 local claude_checked = nil ---@type boolean|nil nil=unchecked
+local launch_queue = {} ---@type { issue: table, callback: fun(ok: boolean, err: string|nil) }[]
+local last_launch_time = 0 ---@type number timestamp (ms) of last successful launch
+local queue_timer = nil ---@type userdata|nil uv timer for processing the queue
+local queue_generation = 0 ---@type integer incremented on _reset to invalidate stale callbacks
+local process_queue ---@type fun() forward declaration
+
+--- Stop and nil the queue timer safely.
+local function stop_queue_timer()
+  if queue_timer then
+    queue_timer:stop()
+    if not queue_timer:is_closing() then
+      queue_timer:close()
+    end
+    queue_timer = nil
+  end
+end
+
+--- Schedule process_queue to fire after delay_ms. Stops any existing timer first.
+---@param delay_ms integer
+local function schedule_queue(delay_ms)
+  if not queue_timer then
+    queue_timer = vim.uv.new_timer()
+  else
+    queue_timer:stop()
+  end
+  local gen = queue_generation
+  queue_timer:start(
+    delay_ms,
+    0,
+    vim.schedule_wrap(function()
+      if gen == queue_generation then
+        process_queue()
+      end
+    end)
+  )
+end
 
 function M._reset()
   active_sessions = {}
   claude_checked = nil
+  launch_queue = {}
+  last_launch_time = 0
+  queue_generation = queue_generation + 1
+  stop_queue_timer()
 end
 ---@return boolean
 function M.is_available()
@@ -238,9 +278,62 @@ local function handle_event(issue_number, event)
         table.insert(parts, session.num_turns .. " turns")
       end
       utils.notify(string.format("Claude finished #%d (%s)", issue_number, table.concat(parts, ", ")))
+      -- Process queue — a slot may have opened up
+      vim.schedule(process_queue)
     end
   end)
 end
+--- Count sessions that are currently running or initializing.
+---@return integer
+function M.running_session_count()
+  local count = 0
+  for _, session in pairs(active_sessions) do
+    if session.status == "running" or session.status == "initializing" then
+      count = count + 1
+    end
+  end
+  return count
+end
+
+--- Process the next item in the launch queue, respecting stagger delay and concurrency limit.
+process_queue = function()
+  if #launch_queue == 0 then
+    stop_queue_timer()
+    return
+  end
+
+  local cfg = config.get().claude
+  local max_sessions = cfg.max_concurrent_sessions or 3
+  local stagger_ms = cfg.launch_stagger_ms or 3000
+
+  -- Check concurrency limit
+  if M.running_session_count() >= max_sessions then
+    schedule_queue(stagger_ms)
+    return
+  end
+
+  -- Check stagger delay (vim.uv.now() resolution is per event-loop tick)
+  local now = vim.uv.now()
+  local elapsed = now - last_launch_time
+  if elapsed < stagger_ms and last_launch_time > 0 then
+    schedule_queue(stagger_ms - elapsed)
+    return
+  end
+
+  -- Dequeue and launch — reserve the slot immediately to prevent re-entry races
+  local entry = table.remove(launch_queue, 1)
+  active_sessions[entry.issue.number] = { status = "initializing" }
+  last_launch_time = vim.uv.now()
+  M._launch_internal(entry.issue, entry.callback)
+
+  -- Schedule next if more in queue, otherwise clean up timer
+  if #launch_queue > 0 then
+    schedule_queue(stagger_ms)
+  else
+    stop_queue_timer()
+  end
+end
+
 function M.launch(issue, callback)
   callback = callback or function() end
   local issue_number = issue.number
@@ -254,6 +347,38 @@ function M.launch(issue, callback)
     callback(false, "Session already running")
     return
   end
+
+  local cfg = config.get().claude
+  local max_sessions = cfg.max_concurrent_sessions or 3
+  local running = M.running_session_count()
+
+  -- If at capacity or queue is non-empty, enqueue
+  if running >= max_sessions or #launch_queue > 0 then
+    if running >= max_sessions then
+      utils.notify(
+        string.format(
+          "Session limit reached (%d/%d) — #%d queued (SQLite contention mitigation)",
+          running,
+          max_sessions,
+          issue_number
+        )
+      )
+    else
+      utils.notify(string.format("#%d queued — staggering launches to avoid SQLite contention", issue_number))
+    end
+    table.insert(launch_queue, { issue = issue, callback = callback })
+    process_queue()
+    return
+  end
+
+  -- Launch immediately (no queue, under limit)
+  last_launch_time = vim.uv.now()
+  M._launch_internal(issue, callback)
+end
+
+function M._launch_internal(issue, callback)
+  callback = callback or function() end
+  local issue_number = issue.number
   active_sessions[issue_number] = { status = "initializing" }
   local stop = utils.spinner_start("Launching Claude for #" .. issue_number .. "...")
   M.check_auth(function(auth_ok, auth_err)
@@ -261,6 +386,7 @@ function M.launch(issue, callback)
       active_sessions[issue_number] = nil
       stop(auth_err)
       callback(false, auth_err)
+      vim.schedule(process_queue)
       return
     end
 
@@ -270,6 +396,7 @@ function M.launch(issue, callback)
         active_sessions[issue_number] = nil
         stop(wt_err or "Failed to create worktree")
         callback(false, wt_err or "Failed to create worktree")
+        vim.schedule(process_queue)
         return
       end
 
@@ -279,6 +406,7 @@ function M.launch(issue, callback)
           active_sessions[issue_number] = nil
           stop(ctx_err or "Failed to fetch issue context")
           callback(false, ctx_err or "Failed to fetch issue context")
+          vim.schedule(process_queue)
           return
         end
 
@@ -353,6 +481,8 @@ function M._launch_headless(issue_number, cmd, wt_path, stop, callback)
           session.status = (exit_code == 0) and "completed" or "failed"
           utils.notify(string.format("Claude finished #%d (%s, exit %d)", issue_number, session.status, exit_code))
         end
+        -- Process queue — a slot may have opened up
+        process_queue()
       end)
     end,
   })
@@ -419,6 +549,8 @@ function M._launch_tmux(issue_number, headless_cmd, wt_path, stop, callback)
       session.status = (exit_code == 0) and "completed" or "failed"
       session.poll_timer = nil
       utils.notify(string.format("Claude finished #%d (%s, exit %d)", issue_number, session.status, exit_code))
+      -- Process queue — a slot may have opened up
+      process_queue()
     end
   end)
 
@@ -494,7 +626,15 @@ function M.stop(issue_number)
   vim.fn.jobstop(session.job_id)
   session.status = "failed"
   utils.notify("Stopped Claude session for #" .. issue_number)
+  -- Process queue — a slot may have opened up
+  vim.schedule(process_queue)
   return true
+end
+
+--- Get the current launch queue (for testing).
+---@return table[]
+function M.get_launch_queue()
+  return launch_queue
 end
 
 return M

--- a/lua/okuban/config.lua
+++ b/lua/okuban/config.lua
@@ -35,6 +35,8 @@ local M = {}
 ---@field max_turns integer
 ---@field model string|nil Override Claude model (e.g. "sonnet", "opus")
 ---@field launch_mode "auto"|"headless"|"tmux" Launch mode: "auto" (tmux if available), "headless", or "tmux"
+---@field max_concurrent_sessions integer Max simultaneous running sessions (default: 3)
+---@field launch_stagger_ms integer Delay between consecutive launches in ms (default: 3000)
 ---@field allowed_tools string[]
 ---@field worktree_base_dir string|nil
 ---@field auto_push boolean
@@ -129,6 +131,8 @@ local defaults = {
     max_turns = 30,
     model = nil,
     launch_mode = "auto",
+    max_concurrent_sessions = 3,
+    launch_stagger_ms = 3000,
     allowed_tools = {
       "Bash(git:*)",
       "Bash(gh:*)",

--- a/tests/test_claude_spec.lua
+++ b/tests/test_claude_spec.lua
@@ -765,6 +765,162 @@ describe("okuban.claude", function()
     end)
   end)
 
+  describe("config defaults for concurrency", function()
+    it("has max_concurrent_sessions as 3 by default", function()
+      local cfg = config.get().claude
+      assert.are.equal(3, cfg.max_concurrent_sessions)
+    end)
+
+    it("has launch_stagger_ms as 3000 by default", function()
+      local cfg = config.get().claude
+      assert.are.equal(3000, cfg.launch_stagger_ms)
+    end)
+
+    it("allows overriding max_concurrent_sessions via setup", function()
+      config.setup({ claude = { max_concurrent_sessions = 1 } })
+      local cfg = config.get().claude
+      assert.are.equal(1, cfg.max_concurrent_sessions)
+    end)
+
+    it("allows overriding launch_stagger_ms via setup", function()
+      config.setup({ claude = { launch_stagger_ms = 5000 } })
+      local cfg = config.get().claude
+      assert.are.equal(5000, cfg.launch_stagger_ms)
+    end)
+  end)
+
+  describe("running_session_count", function()
+    it("returns 0 when no sessions", function()
+      assert.are.equal(0, claude.running_session_count())
+    end)
+
+    it("counts running sessions", function()
+      local sessions = claude.get_all_sessions()
+      sessions[1] = { status = "running", job_id = 1 }
+      sessions[2] = { status = "running", job_id = 2 }
+      sessions[3] = { status = "completed", job_id = 3 }
+      assert.are.equal(2, claude.running_session_count())
+    end)
+
+    it("counts initializing sessions", function()
+      local sessions = claude.get_all_sessions()
+      sessions[1] = { status = "initializing" }
+      sessions[2] = { status = "running", job_id = 2 }
+      assert.are.equal(2, claude.running_session_count())
+    end)
+
+    it("does not count completed or failed sessions", function()
+      local sessions = claude.get_all_sessions()
+      sessions[1] = { status = "completed", job_id = 1 }
+      sessions[2] = { status = "failed", job_id = 2 }
+      assert.are.equal(0, claude.running_session_count())
+    end)
+  end)
+
+  describe("launch queue", function()
+    it("get_launch_queue returns empty table initially", function()
+      assert.are.equal(0, #claude.get_launch_queue())
+    end)
+
+    it("_reset clears the launch queue", function()
+      -- Manually populate queue
+      local queue = claude.get_launch_queue()
+      table.insert(queue, { issue = { number = 99 }, callback = function() end })
+      assert.are.equal(1, #claude.get_launch_queue())
+
+      claude._reset()
+      assert.are.equal(0, #claude.get_launch_queue())
+    end)
+
+    it("enqueues when at max concurrent sessions", function()
+      local orig = vim.fn.executable
+      vim.fn.executable = function(name)
+        if name == "claude" then
+          return 1
+        end
+        return orig(name)
+      end
+      claude._reset()
+
+      -- Fill up to max_concurrent_sessions (default 3)
+      local sessions = claude.get_all_sessions()
+      sessions[1] = { status = "running", job_id = 1 }
+      sessions[2] = { status = "running", job_id = 2 }
+      sessions[3] = { status = "running", job_id = 3 }
+
+      local result_ok
+      claude.launch({ number = 99 }, function(ok, _err)
+        result_ok = ok
+      end)
+
+      -- Should be queued, not launched
+      assert.are.equal(1, #claude.get_launch_queue())
+      assert.is_nil(result_ok) -- callback not called yet
+
+      vim.fn.executable = orig
+    end)
+
+    it("does not enqueue when under limit", function()
+      local orig = vim.fn.executable
+      vim.fn.executable = function(name)
+        if name == "claude" then
+          return 1
+        end
+        return orig(name)
+      end
+      claude._reset()
+
+      -- Only 1 running session, limit is 3
+      local sessions = claude.get_all_sessions()
+      sessions[1] = { status = "running", job_id = 1 }
+
+      -- launch will proceed to _launch_internal which calls check_auth,
+      -- so we mock vim.system for the auth check
+      helpers.mock_vim_system({
+        { code = 1, stdout = "", stderr = "fail" }, -- auth fails, that's fine
+      })
+
+      local done = false
+      claude.launch({ number = 99 }, function(_, _)
+        done = true
+      end)
+
+      -- Should NOT be in the queue
+      assert.are.equal(0, #claude.get_launch_queue())
+
+      vim.wait(1000, function()
+        return done
+      end)
+      vim.fn.executable = orig
+    end)
+
+    it("rejects duplicate running session regardless of queue", function()
+      local orig = vim.fn.executable
+      vim.fn.executable = function(name)
+        if name == "claude" then
+          return 1
+        end
+        return orig(name)
+      end
+      claude._reset()
+
+      local sessions = claude.get_all_sessions()
+      sessions[42] = { status = "running", job_id = 1 }
+
+      local result_ok, result_err
+      claude.launch({ number = 42 }, function(ok, err)
+        result_ok = ok
+        result_err = err
+      end)
+
+      assert.is_false(result_ok)
+      assert.is_truthy(result_err:find("already running"))
+      assert.are.equal(0, #claude.get_launch_queue())
+
+      vim.fn.executable = orig
+    end)
+  end)
+
   describe("_launch_headless race condition fix", function()
     it("session object is created before jobstart", function()
       -- Verify the session is set to running before jobstart returns


### PR DESCRIPTION
## Summary

- Add launch queue with configurable stagger delay (`launch_stagger_ms`, default 3s) and concurrent session limit (`max_concurrent_sessions`, default 3) to prevent SQLite deadlocks when multiple Claude Code processes compete for `~/.claude/__store.db`
- Reserve session slots at dequeue time to prevent re-entry races; generation counter invalidates stale timer callbacks
- Document the upstream SQLite contention issue in README troubleshooting with mitigation config and link to [anthropics/claude-code#14124](https://github.com/anthropics/claude-code/issues/14124)

## Test plan

- [x] 11 new tests covering config defaults, `running_session_count()`, and launch queue behavior
- [x] All 518 tests pass across 19 test files (0 failures)
- [x] Lint clean: 0 warnings / 0 errors (StyLua + Luacheck)
- [ ] Manual: launch 3+ Claude sessions from the board, verify queueing behavior and stagger notifications

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)