### PR TITLE
fix(ui): prevent board from closing on tmux pane switch

### DIFF
--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -364,10 +364,57 @@ function Board:_setup_autocommands()
     end,
   })
 
+  -- Track terminal focus to avoid closing the board on tmux pane switches.
+  -- When Neovim loses focus (FocusLost), Ctrl+l/h/etc. to another tmux pane
+  -- can trigger WinEnter on the underlying non-floating window.  We must
+  -- suppress the "close on WinEnter" logic until FocusGained fires.
+  self._nvim_focused = true
+
+  vim.api.nvim_create_autocmd("FocusLost", {
+    group = self.augroup,
+    callback = function()
+      self._nvim_focused = false
+    end,
+  })
+
+  vim.api.nvim_create_autocmd("FocusGained", {
+    group = self.augroup,
+    callback = function()
+      self._nvim_focused = true
+      -- Re-check: if the user returns to Neovim but the current window
+      -- is not a board window, close the board (deferred to let Neovim settle).
+      vim.schedule(function()
+        if not self:is_open() then
+          return
+        end
+        local win = vim.api.nvim_get_current_win()
+        for _, w in ipairs(self.windows) do
+          if w == win then
+            return
+          end
+        end
+        if self.preview_win and self.preview_win == win then
+          return
+        end
+        local buf = vim.api.nvim_win_get_buf(win)
+        local ft = vim.bo[buf].filetype
+        if ft == "okuban" then
+          return
+        end
+        self:close()
+      end)
+    end,
+  })
+
   -- Close board if focus escapes to a non-board window (e.g. clicking outside)
   vim.api.nvim_create_autocmd("WinEnter", {
     group = self.augroup,
     callback = function()
+      -- Don't close when Neovim itself lost terminal focus (e.g. tmux pane switch)
+      if not self._nvim_focused then
+        return
+      end
+
       local win = vim.api.nvim_get_current_win()
       for _, w in ipairs(self.windows) do
         if w == win then


### PR DESCRIPTION
## Summary
- Track terminal focus with `FocusLost`/`FocusGained` autocmds to prevent the `WinEnter` close handler from firing when Neovim loses terminal focus (e.g. `Ctrl+h/l` to switch tmux panes)
- On `FocusGained`, re-check whether the current window is a board window to preserve click-outside-to-dismiss behavior

Fixes #119

## Test plan
- [ ] Open Okuban board, press `Ctrl+l` to switch tmux panes — board stays open
- [ ] Return to Neovim pane — board remains visible and functional
- [ ] Click outside the board floating windows — board still closes as expected
- [ ] Press `q` or `Esc` — board closes as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)