### PR TITLE
feat(tmux): open okuban board as tmux display-popup overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,22 @@ require("okuban").setup({
 :Okuban
 ```
 
+### tmux Setup (recommended)
+
+If you use tmux, add this line to your `~/.tmux.conf` to open the board as a full-terminal popup above all panes with `prefix + b`:
+
+```tmux
+# okuban.nvim — open kanban board as a floating popup above all panes
+# Requires tmux 3.2+ and okuban.nvim installed in Neovim
+bind-key b display-popup -xC -yC -w 90% -h 90% -e OKUBAN_POPUP=1 -E "nvim +Okuban"
+```
+
+Then reload your config (`prefix + r`, or `tmux source ~/.tmux.conf`).
+
+This is separate from — and complementary to — the `<leader>bb` Neovim keymap. Both open the same board; the tmux binding works from any pane, even when Neovim is not focused.
+
+> **Why `OKUBAN_POPUP=1`?** This env var tells okuban it's running inside a tmux popup so pressing `q` quits Neovim entirely (closing the popup) instead of just closing the board window.
+
 ## Configuration
 
 All options with their defaults:

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ okuban.nvim registers global keymaps on `setup()` using the `<leader>b` prefix (
 
 | Key | Command | Description |
 |-----|---------|-------------|
-| `<leader>bb` | `:Okuban` | Open kanban board |
+| `<leader>bb` | `:Okuban` | Open kanban board (popup in tmux, inline otherwise) |
 | `<leader>bq` | `:OkubanClose` | Close kanban board |
 | `<leader>br` | `:OkubanRefresh` | Refresh kanban board |
 | `<leader>bs` | `:OkubanSetup` | Create kanban labels |
@@ -260,6 +260,19 @@ require("okuban").setup({
       enabled = false,          -- EXPERIMENTAL: Claude agent teams
       teammate_mode = "tmux",   -- "tmux" or "auto"
     },
+  },
+
+  -- tmux integration
+  -- When prefer_popup = true (default), opening the board from inside a tmux
+  -- session launches a display-popup that floats over ALL panes — ideal for
+  -- multi-pane layouts. The popup closes cleanly when you press q or <Esc>.
+  --
+  -- To always use the inline Neovim floating-window board instead:
+  --   tmux = { prefer_popup = false }
+  tmux = {
+    prefer_popup = true,    -- use display-popup when in tmux (spans all panes)
+    popup_width = "90%",    -- width of the popup
+    popup_height = "90%",   -- height of the popup
   },
 })
 ```

--- a/doc/okuban.txt
+++ b/doc/okuban.txt
@@ -48,6 +48,20 @@ Using lazy.nvim: >lua
 
 Then run `:OkubanSetup` to create the kanban labels on your repo.
 
+tmux setup (recommended) ~
+                                                          *okuban-tmux-setup*
+If you use tmux, add this to your `~/.tmux.conf` to open the board as a
+floating popup above all panes with `prefix + b` (requires tmux 3.2+): >tmux
+  bind-key b display-popup -xC -yC -w 90% -h 90% -e OKUBAN_POPUP=1 -E "nvim +Okuban"
+<
+Reload with `tmux source ~/.tmux.conf` (or `prefix + r` if you have that bound).
+
+The `OKUBAN_POPUP=1` env var tells okuban it is inside a popup so pressing
+`q` quits Neovim entirely (which closes the popup window).
+
+This complements the `<leader>bb` Neovim keymap — both open the same board.
+The tmux binding works from any pane, even when Neovim is not focused.
+
 ==============================================================================
 4. COMMANDS                                                 *okuban-commands*
 

--- a/doc/okuban.txt
+++ b/doc/okuban.txt
@@ -261,7 +261,7 @@ global_keymaps                                 *okuban-config-global-keymaps*
   Default prefix: `<leader>b` (b for board).
 
   Key              Default            Command ~
-  open             `<leader>bb`       `:Okuban`
+  open             `<leader>bb`       `:Okuban` (popup in tmux, inline otherwise)
   close            `<leader>bq`       `:OkubanClose`
   refresh          `<leader>br`       `:OkubanRefresh`
   setup            `<leader>bs`       `:OkubanSetup`
@@ -269,6 +269,7 @@ global_keymaps                                 *okuban-config-global-keymaps*
   source_labels    `<leader>bl`       `:OkubanSource labels`
   source_project   `<leader>bp`       `:OkubanSource project`
   migrate          `<leader>bm`       `:OkubanMigrate project`
+  popup            (disabled)         `:OkubanPopup` (explicit popup, no fallback)
 
   Example: >lua
     require("okuban").setup({
@@ -307,6 +308,21 @@ claude                                               *okuban-config-claude*
   - `agent_teams` (table): EXPERIMENTAL Claude agent teams.
     - `enabled` (boolean): Default: false.
     - `teammate_mode` (string): "tmux" or "auto". Default: "tmux".
+
+tmux                                                   *okuban-config-tmux*
+  Type: `table`
+  tmux display-popup integration settings.
+  - `prefer_popup` (boolean): When true (default) and inside a tmux session,
+    `:Okuban` opens as a `display-popup` overlay spanning all panes. Set to
+    false to always use inline Neovim floating windows. Default: true.
+  - `popup_width` (string): Width of the popup. Default: "90%".
+  - `popup_height` (string): Height of the popup. Default: "90%".
+
+  To opt out of the popup behavior: >lua
+    require("okuban").setup({
+      tmux = { prefer_popup = false },
+    })
+<
 
 Highlight Groups ~
                                                     *okuban-highlight-groups*

--- a/lua/okuban/config.lua
+++ b/lua/okuban/config.lua
@@ -28,6 +28,10 @@ local M = {}
 ---@field direction "h"|"v" Split direction: h=side-by-side, v=top-bottom (default: "h")
 ---@field size string|nil Size for new pane (e.g., "50%"), nil=tmux default
 
+---@class OkubanTmuxConfig
+---@field popup_width string Width of the tmux display-popup (default: "90%")
+---@field popup_height string Height of the tmux display-popup (default: "90%")
+
 ---@class OkubanAgentTeamsConfig
 ---@field enabled boolean EXPERIMENTAL: Enable agent teams (default: false)
 ---@field teammate_mode "tmux"|"auto" Teammate mode (default: "tmux")
@@ -61,6 +65,7 @@ local M = {}
 ---@field source_labels string|false
 ---@field source_project string|false
 ---@field migrate string|false
+---@field popup string|false Open board in a tmux display-popup (false = disabled, requires tmux)
 
 ---@class OkubanSortConfig
 ---@field field "updated"|"created"|"number" Sort field (default: "updated")
@@ -75,6 +80,7 @@ local M = {}
 ---@field source "labels"|"project" Data source: "labels" (default) or "project"
 ---@field columns OkubanColumn[]
 ---@field project OkubanProjectConfig
+---@field tmux OkubanTmuxConfig
 ---@field show_unsorted boolean
 ---@field skip_preflight boolean
 ---@field github_hostname string|nil
@@ -143,6 +149,11 @@ local defaults = {
     source_labels = "<leader>bl",
     source_project = "<leader>bp",
     migrate = "<leader>bm",
+    popup = false,
+  },
+  tmux = {
+    popup_width = "90%",
+    popup_height = "90%",
   },
   claude = {
     enabled = true,

--- a/lua/okuban/config.lua
+++ b/lua/okuban/config.lua
@@ -29,6 +29,9 @@ local M = {}
 ---@field size string|nil Size for new pane (e.g., "50%"), nil=tmux default
 
 ---@class OkubanTmuxConfig
+---@field prefer_popup boolean When true and inside a tmux session, :Okuban opens as a
+---                            display-popup overlay spanning all panes (default: true).
+---                            Set to false to always use inline Neovim floating windows.
 ---@field popup_width string Width of the tmux display-popup (default: "90%")
 ---@field popup_height string Height of the tmux display-popup (default: "90%")
 
@@ -151,9 +154,17 @@ local defaults = {
     migrate = "<leader>bm",
     popup = false,
   },
+  -- tmux integration settings
+  -- When prefer_popup = true (default), opening the board from inside a tmux session
+  -- launches a display-popup that floats over ALL panes — ideal for multi-pane layouts.
+  -- The popup closes cleanly when you press q or <Esc>.
+  --
+  -- To always use the inline Neovim floating-window board instead:
+  --   tmux = { prefer_popup = false }
   tmux = {
-    popup_width = "90%",
-    popup_height = "90%",
+    prefer_popup = true,   -- use display-popup when in tmux (spans all panes)
+    popup_width = "90%",   -- width of the popup (percentage of terminal width)
+    popup_height = "90%",  -- height of the popup (percentage of terminal height)
   },
   claude = {
     enabled = true,

--- a/lua/okuban/config.lua
+++ b/lua/okuban/config.lua
@@ -162,9 +162,9 @@ local defaults = {
   -- To always use the inline Neovim floating-window board instead:
   --   tmux = { prefer_popup = false }
   tmux = {
-    prefer_popup = true,   -- use display-popup when in tmux (spans all panes)
-    popup_width = "90%",   -- width of the popup (percentage of terminal width)
-    popup_height = "90%",  -- height of the popup (percentage of terminal height)
+    prefer_popup = true, -- use display-popup when in tmux (spans all panes)
+    popup_width = "90%", -- width of the popup (percentage of terminal width)
+    popup_height = "90%", -- height of the popup (percentage of terminal height)
   },
   claude = {
     enabled = true,

--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -95,8 +95,8 @@ function M.open()
     end
 
     -- For project mode: ensure scope + project selection before opening
-    local cfg = config.get()
-    if cfg.source == "project" and not cfg.project.number then
+    local current_cfg = config.get()
+    if current_cfg.source == "project" and not current_cfg.project.number then
       api.check_project_scope(function(scope_ok, scope_err)
         if not scope_ok then
           utils.notify(scope_err, vim.log.levels.ERROR)
@@ -106,12 +106,12 @@ function M.open()
           if not number then
             return
           end
-          cfg.project.number = number
+          current_cfg.project.number = number
           -- Persist the project selection
           utils.save_state({
             source = "project",
             project_number = number,
-            project_owner = cfg.project.owner,
+            project_owner = current_cfg.project.owner,
           })
           -- Now open the board with the selected project
           board:open_loading()

--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -23,6 +23,7 @@ function M._register_global_keymaps()
     { key = gk.source_labels, cmd = "<cmd>OkubanSource labels<cr>", desc = "Switch to label source" },
     { key = gk.source_project, cmd = "<cmd>OkubanSource project<cr>", desc = "Switch to project source" },
     { key = gk.migrate, cmd = "<cmd>OkubanMigrate project<cr>", desc = "Migrate labels to project" },
+    { key = gk.popup, cmd = "<cmd>OkubanPopup<cr>", desc = "Open kanban board in tmux popup" },
   }
   for _, m in ipairs(map) do
     if m.key and m.key ~= false then
@@ -181,6 +182,18 @@ end
 function M.close()
   local Board = require("okuban.ui.board")
   Board.close_instance()
+end
+
+--- Open the okuban board in a tmux display-popup centered above all panes.
+--- Requires tmux 3.2+. The popup uses OKUBAN_POPUP=1 so pressing `q` quits Neovim.
+function M.open_popup()
+  local tmux = require("okuban.tmux")
+  local cfg = config.get()
+  local tmux_cfg = cfg.tmux or {}
+  tmux.open_board_popup({
+    width = tmux_cfg.popup_width,
+    height = tmux_cfg.popup_height,
+  })
 end
 
 --- Refresh the kanban board.

--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -61,16 +61,31 @@ function M._load_saved_state()
 end
 
 --- Open the kanban board.
+--- When inside a tmux session and tmux.prefer_popup = true (the default), this opens
+--- a display-popup that floats over all panes. Falls back to inline Neovim floating
+--- windows when not in tmux, or when prefer_popup = false.
 function M.open()
   -- Restore saved per-repo state on first open
   M._load_saved_state()
 
+  -- Route to tmux popup when inside a tmux session and prefer_popup is enabled.
+  -- This makes <leader>bb span all panes instead of only the current Neovim pane.
+  -- Skip when already inside a popup (OKUBAN_POPUP=1) to prevent nested popups.
+  local cfg = config.get()
+  if cfg.tmux.prefer_popup and require("okuban.tmux").is_available() and vim.env.OKUBAN_POPUP ~= "1" then
+    M.open_popup()
+    return
+  end
+
   local Board = require("okuban.ui.board")
   local board = Board.get_instance()
 
-  -- If board is already open, close it first (toggle behavior)
+  -- Toggle behavior: close if already open — but not in popup mode, where the
+  -- VimEnter autocmd and any +Okuban command may both call open().
   if board:is_open() then
-    board:close()
+    if vim.env.OKUBAN_POPUP ~= "1" then
+      board:close()
+    end
     return
   end
 

--- a/lua/okuban/tmux.lua
+++ b/lua/okuban/tmux.lua
@@ -182,6 +182,42 @@ function M.write_launcher_script(cmd, sentinel)
   return script
 end
 
+--- Build the tmux display-popup command to open okuban in a floating overlay.
+--- Sets OKUBAN_POPUP=1 so the board knows to quit Neovim on close.
+---@param opts { width?: string, height?: string }|nil
+---@return string[] cmd
+function M.build_popup_command(opts)
+  opts = opts or {}
+  local width = opts.width or "90%"
+  local height = opts.height or "90%"
+  return {
+    "tmux",
+    "display-popup",
+    "-xC",
+    "-yC",
+    "-w",
+    width,
+    "-h",
+    height,
+    "-e",
+    "OKUBAN_POPUP=1",
+    "-E",
+    "nvim +Okuban",
+  }
+end
+
+--- Open the okuban board in a tmux display-popup centered above all panes.
+--- Requires tmux 3.2+. Shows a warning if not inside a tmux session.
+---@param opts { width?: string, height?: string }|nil
+function M.open_board_popup(opts)
+  if not M.is_available() then
+    vim.notify("okuban: OkubanPopup requires an active tmux session (TMUX not set)", vim.log.levels.WARN)
+    return
+  end
+  local cmd = M.build_popup_command(opts)
+  vim.system(cmd, { text = true }):wait()
+end
+
 --- Write prompt text to a temp file for safe passing to Claude via tmux.
 --- This avoids all shell quoting issues with complex multi-line prompts.
 ---@param text string Prompt text

--- a/lua/okuban/ui/navigation.lua
+++ b/lua/okuban/ui/navigation.lua
@@ -602,6 +602,9 @@ function Navigation:setup_keymaps(buf)
 
   vim.keymap.set("n", keymaps.close, function()
     self.board:close()
+    if vim.env.OKUBAN_POPUP == "1" then
+      vim.cmd("qa!")
+    end
   end, opts)
 
   -- Esc: collapse tree → exit issue mode → close board (cascade)
@@ -619,6 +622,9 @@ function Navigation:setup_keymaps(buf)
         self:toggle_issue_mode()
       else
         self.board:close()
+        if vim.env.OKUBAN_POPUP == "1" then
+          vim.cmd("qa!")
+        end
       end
     end, opts)
   end

--- a/plugin/okuban.lua
+++ b/plugin/okuban.lua
@@ -55,3 +55,22 @@ vim.api.nvim_create_user_command("OkubanMigrate", function(cmd)
   end
   require("okuban").migrate_to_project(number)
 end, { desc = "Migrate label board into a GitHub Project", nargs = "+" })
+
+-- In popup mode (OKUBAN_POPUP=1): suppress the intro screen and open the board at
+-- VimEnter time. This fires before any -c commands and before dashboard plugins,
+-- so the user sees the board immediately when the popup window appears.
+if vim.env.OKUBAN_POPUP == "1" then
+  vim.opt.shortmess:append("I")
+  -- Disable dashboard-nvim so it doesn't flash before the board appears
+  vim.g.loaded_dashboard = 1
+  vim.api.nvim_create_autocmd("VimEnter", {
+    once = true,
+    nested = true,
+    callback = function()
+      -- vim.schedule lets lazy.nvim finish its final setup pass before we open
+      vim.schedule(function()
+        require("okuban").open()
+      end)
+    end,
+  })
+end

--- a/plugin/okuban.lua
+++ b/plugin/okuban.lua
@@ -41,6 +41,10 @@ vim.api.nvim_create_user_command("OkubanTriage", function()
   end)
 end, { desc = "Triage existing issues into okuban kanban columns" })
 
+vim.api.nvim_create_user_command("OkubanPopup", function()
+  require("okuban").open_popup()
+end, { desc = "Open okuban kanban board in a tmux display-popup" })
+
 vim.api.nvim_create_user_command("OkubanMigrate", function(cmd)
   local args = vim.split(cmd.args, "%s+", { trimempty = true })
   local target = args[1]

--- a/tests/test_tmux_spec.lua
+++ b/tests/test_tmux_spec.lua
@@ -34,6 +34,87 @@ describe("okuban.tmux", function()
     end)
   end)
 
+  describe("build_popup_command", function()
+    it("builds display-popup command with defaults", function()
+      local cmd = tmux.build_popup_command()
+      assert.are.equal("tmux", cmd[1])
+      assert.are.equal("display-popup", cmd[2])
+      assert.are.equal("-xC", cmd[3])
+      assert.are.equal("-yC", cmd[4])
+      assert.are.equal("-w", cmd[5])
+      assert.are.equal("90%", cmd[6])
+      assert.are.equal("-h", cmd[7])
+      assert.are.equal("90%", cmd[8])
+      assert.are.equal("-e", cmd[9])
+      assert.are.equal("OKUBAN_POPUP=1", cmd[10])
+      assert.are.equal("-E", cmd[11])
+      assert.are.equal("nvim +Okuban", cmd[12])
+    end)
+
+    it("respects custom width and height", function()
+      local cmd = tmux.build_popup_command({ width = "80%", height = "70%" })
+      assert.are.equal("80%", cmd[6])
+      assert.are.equal("70%", cmd[8])
+    end)
+
+    it("sets OKUBAN_POPUP=1 env var", function()
+      local cmd = tmux.build_popup_command()
+      local found = false
+      for i, v in ipairs(cmd) do
+        if v == "-e" and cmd[i + 1] == "OKUBAN_POPUP=1" then
+          found = true
+        end
+      end
+      assert.is_true(found, "expected -e OKUBAN_POPUP=1 in command")
+    end)
+  end)
+
+  describe("open_board_popup", function()
+    it("shows warning when tmux is not available", function()
+      local orig = vim.env.TMUX
+      vim.env.TMUX = nil
+      local warned = false
+      local orig_notify = vim.notify
+      vim.notify = function(_, level)
+        if level == vim.log.levels.WARN then
+          warned = true
+        end
+      end
+      tmux.open_board_popup()
+      vim.notify = orig_notify
+      vim.env.TMUX = orig
+      assert.is_true(warned)
+    end)
+
+    it("calls tmux display-popup when in tmux session", function()
+      local orig = vim.env.TMUX
+      vim.env.TMUX = "/tmp/tmux-1000/default,12345,0"
+      local calls = helpers.mock_vim_system({ { code = 0 } })
+      tmux.open_board_popup()
+      vim.env.TMUX = orig
+      assert.are.equal(1, #calls)
+      assert.are.equal("tmux", calls[1].cmd[1])
+      assert.are.equal("display-popup", calls[1].cmd[2])
+    end)
+
+    it("passes custom width and height to the command", function()
+      local orig = vim.env.TMUX
+      vim.env.TMUX = "/tmp/tmux-1000/default,12345,0"
+      local calls = helpers.mock_vim_system({ { code = 0 } })
+      tmux.open_board_popup({ width = "75%", height = "65%" })
+      vim.env.TMUX = orig
+      local cmd = calls[1].cmd
+      local w_idx = nil
+      for i, v in ipairs(cmd) do
+        if v == "-w" then
+          w_idx = i
+        end
+      end
+      assert.is_not_nil(w_idx)
+      assert.are.equal("75%", cmd[w_idx + 1])
+    end)
+  end)
+
   describe("build_launch_command", function()
     it("builds tmux new-window command with correct structure", function()
       local cmd, sentinel = tmux.build_launch_command({


### PR DESCRIPTION
## Summary
- Add `OkubanPopup` command that opens the kanban board as a centered tmux `display-popup` overlay
- Board spans all panes, configurable width/height (`tmux.popup_width`, `tmux.popup_height`)
- Graceful error if not running inside tmux
- Documentation for `~/.tmux.conf` keybinding setup

Fixes #150

## Test plan
- [x] `:OkubanPopup` opens centered popup with board
- [x] `q` closes the popup
- [x] Graceful error outside tmux
- [x] Config options for width/height work
- [x] tmux.conf binding documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)