### PR TITLE
feat(labels): filter sub-issues from board and show as tree items only

### DIFF
--- a/lua/okuban/api.lua
+++ b/lua/okuban/api.lua
@@ -217,13 +217,13 @@ function M.expand_column(col_index, callback)
   return require("okuban.api_labels").expand_column(col_index, callback)
 end
 
---- Fetch sub-issue counts for a list of issue numbers. Routes based on source.
+--- Fetch sub-issue counts and parent info for a list of issue numbers.
 --- In project mode, counts are embedded in issue objects (no extra call needed).
 ---@param issue_numbers integer[]
----@param callback fun(counts: table<integer, {total: integer, completed: integer}>)
+---@param callback fun(counts: table, parent_map: table)
 function M.fetch_sub_issue_counts(issue_numbers, callback)
   if config.get().source == "project" then
-    callback({})
+    callback({}, {})
     return
   end
   return require("okuban.api_labels").fetch_sub_issue_counts(issue_numbers, callback)

--- a/lua/okuban/api_labels.lua
+++ b/lua/okuban/api_labels.lua
@@ -295,24 +295,26 @@ end
 -- Sub-issue counts
 -- ---------------------------------------------------------------------------
 
---- Batch-fetch sub-issue counts via GraphQL aliases.
+--- Batch-fetch sub-issue counts and parent info via GraphQL aliases.
+--- Returns counts (for badges) and parent_map (for filtering sub-issues from board).
 ---@param issue_numbers integer[]
----@param callback fun(counts: table<integer, {total: integer, completed: integer}>)
+---@param callback fun(counts: table, parent_map: table)
 function M.fetch_sub_issue_counts(issue_numbers, callback)
   if not issue_numbers or #issue_numbers == 0 then
-    callback({})
+    callback({}, {})
     return
   end
 
   local api = require("okuban.api")
   api.detect_repo_info(function(owner, name)
     if not owner or not name then
-      callback({})
+      callback({}, {})
       return
     end
 
     -- Build batched alias query (chunks of 25 to avoid oversized queries)
     local all_counts = {}
+    local all_parents = {} -- issue_number → parent_number (for sub-issue filtering)
     local chunks = {}
     for i = 1, #issue_numbers, 25 do
       local chunk = {}
@@ -324,7 +326,7 @@ function M.fetch_sub_issue_counts(issue_numbers, callback)
 
     local pending = #chunks
     if pending == 0 then
-      callback({})
+      callback({}, {})
       return
     end
 
@@ -333,7 +335,7 @@ function M.fetch_sub_issue_counts(issue_numbers, callback)
       for _, num in ipairs(chunk) do
         table.insert(
           aliases,
-          string.format("i%d: issue(number: %d) { subIssuesSummary { total completed } }", num, num)
+          string.format("i%d: issue(number: %d) { subIssuesSummary { total completed } parent { number } }", num, num)
         )
       end
 
@@ -357,10 +359,16 @@ function M.fetch_sub_issue_counts(issue_numbers, callback)
               local repo = data.data.repository
               for _, num in ipairs(chunk) do
                 local key = "i" .. num
-                if repo[key] and repo[key].subIssuesSummary then
-                  local s = repo[key].subIssuesSummary
-                  if s.total and s.total > 0 then
-                    all_counts[num] = { total = s.total, completed = s.completed or 0 }
+                if repo[key] then
+                  local entry = repo[key]
+                  if entry.subIssuesSummary then
+                    local s = entry.subIssuesSummary
+                    if s.total and s.total > 0 then
+                      all_counts[num] = { total = s.total, completed = s.completed or 0 }
+                    end
+                  end
+                  if entry.parent and entry.parent ~= vim.NIL and entry.parent.number then
+                    all_parents[num] = entry.parent.number
                   end
                 end
               end
@@ -369,7 +377,7 @@ function M.fetch_sub_issue_counts(issue_numbers, callback)
 
           pending = pending - 1
           if pending == 0 then
-            callback(all_counts)
+            callback(all_counts, all_parents)
           end
         end)
       end)

--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -657,13 +657,64 @@ function Board:populate(data)
   end
   if #all_numbers > 0 then
     local api = require("okuban.api")
-    api.fetch_sub_issue_counts(all_numbers, function(counts)
+    api.fetch_sub_issue_counts(all_numbers, function(counts, parent_map)
       if not self:is_open() then
         return
       end
+
+      -- Filter sub-issues from the board (label mode only).
+      -- Issues that have a parent are sub-issues and should only appear
+      -- in the tree view, not as standalone cards on the board.
+      local filtered_any = false
+      if parent_map and not vim.tbl_isempty(parent_map) then
+        for i, col in ipairs(self.columns) do
+          local original_count = #col.issues
+          local filtered = {}
+          for _, issue in ipairs(col.issues) do
+            if not parent_map[issue.number] then
+              table.insert(filtered, issue)
+            end
+          end
+          if #filtered < original_count then
+            col.issues = filtered
+            filtered_any = true
+            -- Update column title with new count
+            local win = self.windows[i]
+            if win and vim.api.nvim_win_is_valid(win) then
+              local title = format_title(col.name, #col.issues, col.limit)
+              vim.api.nvim_win_set_config(win, { title = title, title_pos = "center" })
+            end
+          end
+        end
+      end
+
       if not counts or vim.tbl_isempty(counts) then
+        if filtered_any then
+          -- Still need to re-render even without counts, since we removed cards
+          local re_sessions = claude.get_all_sessions()
+          local tree = require("okuban.ui.tree")
+          for i, col in ipairs(self.columns) do
+            if not col._visible_items or not tree.has_any_expanded(i) then
+              local buf = self.buffers[i]
+              if buf and vim.api.nvim_buf_is_valid(buf) then
+                local iw = self:get_column_width(i) - 2
+                local lines, card_ranges =
+                  card.render_column(col.issues, iw, self.worktree_map, re_sessions, self.sub_issue_counts)
+                col.card_ranges = card_ranges
+                vim.bo[buf].modifiable = true
+                vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+                vim.bo[buf].modifiable = false
+              end
+            end
+          end
+          if self.navigation then
+            self.navigation:clamp_position()
+            self.navigation:highlight_current()
+          end
+        end
         return
       end
+
       self.sub_issue_counts = counts
       -- Re-render columns with sub-issue badges (skip tree-expanded columns)
       local re_sessions = claude.get_all_sessions()
@@ -683,6 +734,9 @@ function Board:populate(data)
         end
       end
       if self.navigation then
+        if filtered_any then
+          self.navigation:clamp_position()
+        end
         self.navigation:highlight_current()
       end
     end)

--- a/lua/okuban/ui/navigation.lua
+++ b/lua/okuban/ui/navigation.lua
@@ -36,6 +36,23 @@ function Navigation:num_columns()
   return #self.board.columns
 end
 
+--- Clamp column and card indices to valid ranges after cards are removed.
+function Navigation:clamp_position()
+  local ncols = self:num_columns()
+  if ncols == 0 then
+    return
+  end
+  self.column_index = math.min(self.column_index, ncols)
+  local count = self:card_count(self.column_index)
+  if count == 0 then
+    self.card_index = 1
+  else
+    self.card_index = math.min(self.card_index, count)
+  end
+  -- Reset tree sub-index since the expanded card may have been removed
+  self._tree_sub_index = 0
+end
+
 --- Move to the next column (right).
 function Navigation:move_right()
   if self.column_index < self:num_columns() then

--- a/tests/test_api_fetch_spec.lua
+++ b/tests/test_api_fetch_spec.lua
@@ -334,21 +334,25 @@ describe("okuban.api fetch", function()
   end)
 
   describe("fetch_sub_issue_counts", function()
-    it("returns empty table on empty input", function()
+    it("returns empty tables on empty input", function()
       local done = false
-      local result = nil
+      local result_counts = nil
+      local result_parents = nil
       -- Need api_labels module directly for label-mode fetch
       local api_labels = require("okuban.api_labels")
-      api_labels.fetch_sub_issue_counts({}, function(counts)
+      api_labels.fetch_sub_issue_counts({}, function(counts, parent_map)
         done = true
-        result = counts
+        result_counts = counts
+        result_parents = parent_map
       end)
 
       vim.wait(1000, function()
         return done
       end)
-      assert.is_not_nil(result)
-      assert.equals(0, vim.tbl_count(result))
+      assert.is_not_nil(result_counts)
+      assert.equals(0, vim.tbl_count(result_counts))
+      assert.is_not_nil(result_parents)
+      assert.equals(0, vim.tbl_count(result_parents))
     end)
 
     it("parses GraphQL response correctly", function()
@@ -357,9 +361,9 @@ describe("okuban.api fetch", function()
       local graphql_response = vim.json.encode({
         data = {
           repository = {
-            i10 = { subIssuesSummary = { total = 3, completed = 1 } },
-            i20 = { subIssuesSummary = { total = 0, completed = 0 } },
-            i30 = { subIssuesSummary = { total = 5, completed = 5 } },
+            i10 = { subIssuesSummary = { total = 3, completed = 1 }, parent = vim.NIL },
+            i20 = { subIssuesSummary = { total = 0, completed = 0 }, parent = vim.NIL },
+            i30 = { subIssuesSummary = { total = 5, completed = 5 }, parent = vim.NIL },
           },
         },
       })
@@ -374,9 +378,11 @@ describe("okuban.api fetch", function()
 
       local done = false
       local result = nil
-      api_labels.fetch_sub_issue_counts({ 10, 20, 30 }, function(counts)
+      local parents = nil
+      api_labels.fetch_sub_issue_counts({ 10, 20, 30 }, function(counts, parent_map)
         done = true
         result = counts
+        parents = parent_map
       end)
 
       vim.wait(2000, function()
@@ -394,6 +400,50 @@ describe("okuban.api fetch", function()
       assert.is_not_nil(result[30])
       assert.equals(5, result[30].total)
       assert.equals(5, result[30].completed)
+      -- No parents (none are sub-issues)
+      assert.is_not_nil(parents)
+      assert.equals(0, vim.tbl_count(parents))
+    end)
+
+    it("detects sub-issues via parent field", function()
+      local graphql_response = vim.json.encode({
+        data = {
+          repository = {
+            i10 = { subIssuesSummary = { total = 2, completed = 0 }, parent = vim.NIL },
+            i11 = { subIssuesSummary = { total = 0, completed = 0 }, parent = { number = 10 } },
+            i12 = { subIssuesSummary = { total = 0, completed = 0 }, parent = { number = 10 } },
+          },
+        },
+      })
+      helpers.mock_vim_system({
+        { code = 0, stdout = "alice|myrepo" },
+        { code = 0, stdout = graphql_response },
+      })
+
+      local api_labels = require("okuban.api_labels")
+      api._reset_repo_info()
+
+      local done = false
+      local result_counts = nil
+      local result_parents = nil
+      api_labels.fetch_sub_issue_counts({ 10, 11, 12 }, function(counts, parent_map)
+        done = true
+        result_counts = counts
+        result_parents = parent_map
+      end)
+
+      vim.wait(2000, function()
+        return done
+      end)
+
+      -- Issue 10 is a parent with 2 sub-issues
+      assert.is_not_nil(result_counts[10])
+      assert.equals(2, result_counts[10].total)
+      -- Issues 11 and 12 are sub-issues of 10
+      assert.equals(10, result_parents[11])
+      assert.equals(10, result_parents[12])
+      -- Issue 10 is NOT a sub-issue
+      assert.is_nil(result_parents[10])
     end)
 
     it("handles API errors gracefully", function()
@@ -407,7 +457,7 @@ describe("okuban.api fetch", function()
 
       local done = false
       local result = nil
-      api_labels.fetch_sub_issue_counts({ 10, 20 }, function(counts)
+      api_labels.fetch_sub_issue_counts({ 10, 20 }, function(counts, _parent_map)
         done = true
         result = counts
       end)

--- a/tests/test_navigation_spec.lua
+++ b/tests/test_navigation_spec.lua
@@ -340,6 +340,39 @@ describe("okuban.ui.navigation", function()
     end)
   end)
 
+  describe("clamp_position", function()
+    it("clamps card_index when cards are removed", function()
+      local board = mock_board({ 5, 3 })
+      local nav = Navigation.new(board)
+      nav.card_index = 5 -- at last card in col 1
+      -- Remove 2 cards from col 1
+      board.columns[1].issues = { board.columns[1].issues[1], board.columns[1].issues[2], board.columns[1].issues[3] }
+      nav:clamp_position()
+      assert.equals(3, nav.card_index)
+    end)
+
+    it("clamps column_index when columns are removed", function()
+      local board = mock_board({ 3, 2 })
+      local nav = Navigation.new(board)
+      nav.column_index = 2
+      nav.card_index = 2
+      -- Remove col 2
+      table.remove(board.columns, 2)
+      nav:clamp_position()
+      assert.equals(1, nav.column_index)
+      -- card_index 2 is valid for col 1 (which has 3 cards)
+      assert.equals(2, nav.card_index)
+    end)
+
+    it("resets _tree_sub_index", function()
+      local board = mock_board({ 3 })
+      local nav = Navigation.new(board)
+      nav._tree_sub_index = 2
+      nav:clamp_position()
+      assert.equals(0, nav._tree_sub_index)
+    end)
+  end)
+
   describe("tree navigation", function()
     it("starts with _tree_sub_index = 0", function()
       local board = mock_board({ 3 })


### PR DESCRIPTION
## Summary
- Sub-issues with kanban labels no longer appear as standalone cards on the board in label mode
- They are only visible via the tree expand/collapse under their parent card
- Extends the existing GraphQL batch query to also fetch `parent { number }` — no extra API call
- Adds `clamp_position()` to navigation for safe cursor adjustment after cards are removed

Fixes #152

## Test plan
- [x] `fetch_sub_issue_counts` returns parent_map alongside counts
- [x] Sub-issues detected via `parent { number }` field in GraphQL response
- [x] Empty input returns empty tables for both counts and parent_map
- [x] API errors handled gracefully
- [x] `clamp_position` clamps card/column indices after card removal
- [x] `clamp_position` resets tree sub-index
- [x] Full test suite passes (lint + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)