### PR TITLE
fix(ui): eliminate sub-issue flicker on board open

### DIFF
--- a/lua/okuban/api.lua
+++ b/lua/okuban/api.lua
@@ -237,6 +237,16 @@ function M.fetch_sub_issues(parent_number, callback)
   return require("okuban.api_labels").fetch_sub_issues(parent_number, callback)
 end
 
+--- Return the cached parent_map (label-mode only).
+--- Returns nil if never fetched or in project mode.
+---@return table<integer, integer>|nil
+function M.get_cached_parent_map()
+  if config.get().source == "project" then
+    return nil
+  end
+  return require("okuban.api_labels").get_cached_parent_map()
+end
+
 --- Fetch issues for a single label (label-mode only).
 ---@param label string The label to filter by
 ---@param state string|nil Issue state filter

--- a/lua/okuban/api_labels.lua
+++ b/lua/okuban/api_labels.lua
@@ -6,6 +6,10 @@ local M = {}
 local board_cache = nil ---@type table|nil
 local board_cache_ts = 0 ---@type integer
 
+--- Session-level parent_map cache (issue_number → parent_number).
+--- nil = never fetched. {} = fetched, no parents found.
+local parent_map_cache = nil ---@type table<integer, integer>|nil
+
 --- Get the gh base command from the shared api module.
 ---@return string[]
 local function gh_base_cmd()
@@ -377,12 +381,25 @@ function M.fetch_sub_issue_counts(issue_numbers, callback)
 
           pending = pending - 1
           if pending == 0 then
+            parent_map_cache = all_parents
             callback(all_counts, all_parents)
           end
         end)
       end)
     end
   end)
+end
+
+--- Return the cached parent_map from the most recent fetch_sub_issue_counts call.
+--- Returns nil if never fetched, otherwise a table (possibly empty).
+---@return table<integer, integer>|nil
+function M.get_cached_parent_map()
+  return parent_map_cache
+end
+
+--- Reset the parent_map cache (for testing).
+function M._reset_parent_map_cache()
+  parent_map_cache = nil
 end
 
 -- ---------------------------------------------------------------------------

--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -134,7 +134,21 @@ local CACHE_MAX_AGE = 3600 -- 1 hour
 ---@param data table Board data from api.fetch_all_columns
 ---@param skip_focus boolean If true, skip auto-focus (used for cached data)
 function M._populate_board(board, data, skip_focus)
-  board:populate(data)
+  -- Auto-focus runs after the board has fully painted (navigation ready).
+  local on_painted = nil
+  if not skip_focus then
+    on_painted = function()
+      local detect = require("okuban.detect")
+      detect.detect_issue(function(issue_number)
+        if not issue_number or not board:is_open() or not board.navigation then
+          return
+        end
+        board.navigation:focus_issue(issue_number)
+      end)
+    end
+  end
+
+  board:populate(data, on_painted)
 
   -- First-open hint: if all kanban columns empty but unsorted has issues
   if not board._hint_shown then
@@ -149,17 +163,6 @@ function M._populate_board(board, data, skip_focus)
     if all_empty and data.unsorted and #data.unsorted > 0 then
       utils.notify("Tip: press Enter on a card to triage it into a column, or m to move it directly")
     end
-  end
-
-  -- Auto-focus: detect current issue and navigate to it
-  if not skip_focus then
-    local detect = require("okuban.detect")
-    detect.detect_issue(function(issue_number)
-      if not issue_number or not board:is_open() or not board.navigation then
-        return
-      end
-      board.navigation:focus_issue(issue_number)
-    end)
   end
 end
 

--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -94,6 +94,14 @@ function M.open()
       return
     end
 
+    -- Re-check after async preflight: another open() may have raced ahead
+    -- (notably in tmux popup mode where -c Okuban and the VimEnter autocmd
+    -- both call open(), and both can pass the outer is_open() check before
+    -- either one's preflight completes).
+    if board:is_open() then
+      return
+    end
+
     -- For project mode: ensure scope + project selection before opening
     local current_cfg = config.get()
     if current_cfg.source == "project" and not current_cfg.project.number then
@@ -102,8 +110,11 @@ function M.open()
           utils.notify(scope_err, vim.log.levels.ERROR)
           return
         end
+        if board:is_open() then
+          return
+        end
         M._pick_project(function(number)
-          if not number then
+          if not number or board:is_open() then
             return
           end
           current_cfg.project.number = number

--- a/lua/okuban/init.lua
+++ b/lua/okuban/init.lua
@@ -127,13 +127,17 @@ function M.open()
   end)
 end
 
-local CACHE_MAX_AGE = 3600 -- 1 hour
-
 --- Populate board with data and run first-open checks.
 ---@param board table Board instance
 ---@param data table Board data from api.fetch_all_columns
 ---@param skip_focus boolean If true, skip auto-focus (used for cached data)
 function M._populate_board(board, data, skip_focus)
+  -- Bail if the user closed the board during the fetch — we don't want
+  -- populate's column-mismatch fallback to re-open it against their wishes.
+  if not board:is_open() then
+    return
+  end
+
   -- Auto-focus runs after the board has fully painted (navigation ready).
   local on_painted = nil
   if not skip_focus then
@@ -167,24 +171,13 @@ function M._populate_board(board, data, skip_focus)
 end
 
 --- Fetch data and populate an already-opened loading board.
---- If cached data is available (< 1h old), shows it instantly and refreshes in background.
+--- Always waits for the fresh fetch before painting so the user sees a
+--- single transition from the loading skeleton to the final cards. The
+--- previous "show stale cache instantly, refresh in background" path was
+--- removed because it caused two visible paints (cached then fresh) which
+--- the user perceived as a flicker.
 ---@param board table Board instance (already showing loading skeleton)
 function M._open_board(board)
-  -- Try cached data first for instant display
-  local cached = api.get_cached_board_data(CACHE_MAX_AGE)
-  if cached then
-    M._populate_board(board, cached, false)
-    -- Refresh immediately in background, then start limited auto-refresh cycle
-    api.fetch_all_columns(function(data)
-      if data and board:is_open() then
-        board:refresh(data)
-        board:_start_auto_refresh()
-      end
-    end)
-    return
-  end
-
-  -- No cache — fetch fresh (loading skeleton already visible)
   api.fetch_all_columns(function(data)
     if not data then
       utils.notify("Failed to fetch issues", vim.log.levels.ERROR)

--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -638,9 +638,14 @@ function Board:_setup_or_update_navigation()
 end
 
 --- Populate existing loading windows with real data in-place.
---- Sets up navigation and full keymaps.
+--- Waits for ALL async data fetches (worktree enrichment + sub-issue
+--- metadata) before painting so the user sees one fully-formed render
+--- instead of a sequence of partial renders. The buffers retain their
+--- prior contents (loading skeleton on cold open, previous cards on
+--- refresh) until the single paint fires.
 ---@param data table Board data from api.fetch_all_columns
-function Board:populate(data)
+---@param on_painted fun()|nil Called once after the single paint completes.
+function Board:populate(data, on_painted)
   self.data = data
   local cols = build_column_list(data)
 
@@ -648,6 +653,9 @@ function Board:populate(data)
   if #cols ~= #self.windows then
     self:close()
     self:open(data)
+    if on_painted then
+      on_painted()
+    end
     return
   end
 
@@ -668,62 +676,19 @@ function Board:populate(data)
   -- Verify headless session liveness before rendering badges
   claude.verify_sessions()
 
-  -- Fetch worktree map (sync, ~4ms) for card badges
+  -- Sync worktree fetch (~4ms). Used as a fallback if enrichment times out.
   local wt_map = worktree.fetch_worktree_map()
-  self.worktree_map = wt_map
-  local sessions = claude.get_all_sessions()
 
-  -- Apply cached parent_map filter pre-render so known sub-issues never flash.
+  -- Generation guard: subsequent populate calls invalidate prior async chains.
+  self._populate_gen = (self._populate_gen or 0) + 1
+  local gen = self._populate_gen
+
+  -- Cached parent_map serves as fallback when fetch_sub_issue_counts hangs
+  -- so the timeout render still strips known sub-issues.
   local api = require("okuban.api")
   local cached_parent_map = (api.get_cached_parent_map and api.get_cached_parent_map()) or nil
-  if cached_parent_map and not vim.tbl_isempty(cached_parent_map) then
-    filter_sub_issues_in_place(cols, cached_parent_map)
-  end
 
-  -- Cold first paint: no cached parent_map AND no prior render means buffers
-  -- still hold the "Loading..." skeleton from open_loading(). Defer the first
-  -- paint until fresh parent_map arrives so sub-issues never appear at all.
-  local cold_first_paint = self.columns == nil and cached_parent_map == nil
-
-  if not cold_first_paint then
-    self:_paint_columns(cols, layout, wt_map, sessions, self.sub_issue_counts)
-    self:_setup_or_update_navigation()
-  end
-
-  -- Async: enrich worktree map with dirty/clean status. Skips if buffers
-  -- haven't been painted yet (cold path); the post-fetch_sub_issue_counts
-  -- paint will own the first render and worktree enrichment will overlay
-  -- once it completes (or already has, via self.worktree_map below).
-  worktree.fetch_enriched(function(enriched_map)
-    if not self:is_open() then
-      return
-    end
-    self.worktree_map = enriched_map
-    if not self.columns then
-      return
-    end
-    local re_sessions = claude.get_all_sessions()
-    for i, col in ipairs(self.columns) do
-      local buf = self.buffers[i]
-      if buf and vim.api.nvim_buf_is_valid(buf) then
-        local inner_width = layout.col_width - 2
-        local lines, card_ranges =
-          card.render_column(col.issues, inner_width, enriched_map, re_sessions, self.sub_issue_counts)
-        col.card_ranges = card_ranges
-        vim.bo[buf].modifiable = true
-        vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-        vim.bo[buf].modifiable = false
-      end
-    end
-    self:_apply_active_highlights(enriched_map)
-    if self.navigation then
-      self.navigation:highlight_current()
-    end
-  end)
-
-  -- Async: fresh sub-issue counts + parent_map.
-  --   Cold path: this triggers the first paint with the filter applied.
-  --   Warm path: re-renders if parent_map changed and updates badges with counts.
+  -- Collect raw issue numbers for the sub-issue count GraphQL query.
   local all_numbers = {}
   for _, raw_col in ipairs(build_column_list(data)) do
     for _, issue in ipairs(raw_col.issues) do
@@ -731,75 +696,69 @@ function Board:populate(data)
     end
   end
 
-  if #all_numbers == 0 then
-    if cold_first_paint and self.columns == nil then
-      self:_paint_columns(cols, layout, wt_map, sessions, self.sub_issue_counts)
-      self:_setup_or_update_navigation()
+  -- Async barrier: paint_now fires once both fetches resolve (or after the
+  -- safety-net timeout). All paint state is captured here so callbacks
+  -- compose into a single render.
+  local pending = 2 -- worktree.fetch_enriched + fetch_sub_issue_counts
+  local painted = false
+  local enriched_wt_map = nil
+  local fresh_counts = nil
+  local fresh_parent_map = nil
+
+  local function paint_now()
+    if painted or self._populate_gen ~= gen or not self:is_open() then
+      return
     end
+    painted = true
+
+    local pm = fresh_parent_map or cached_parent_map or {}
+    local final_cols = build_column_list(data)
+    filter_sub_issues_in_place(final_cols, pm)
+    self.sub_issue_counts = fresh_counts or self.sub_issue_counts or {}
+    self.worktree_map = enriched_wt_map or wt_map
+
+    self:_paint_columns(final_cols, layout, self.worktree_map, claude.get_all_sessions(), self.sub_issue_counts)
+    self:_setup_or_update_navigation()
+
     header.set_last_updated(os.time())
-    return
+
+    if on_painted then
+      on_painted()
+    end
   end
 
-  api.fetch_sub_issue_counts(all_numbers, function(counts, fresh_parent_map)
-    if not self:is_open() then
+  local function on_async_done()
+    if self._populate_gen ~= gen then
       return
     end
-
-    local fresh_cols = build_column_list(data)
-    filter_sub_issues_in_place(fresh_cols, fresh_parent_map or {})
-    self.sub_issue_counts = counts or {}
-
-    if self.columns == nil then
-      -- Cold path: first paint.
-      self:_paint_columns(fresh_cols, layout, self.worktree_map, claude.get_all_sessions(), counts)
-      self:_setup_or_update_navigation()
-      return
+    pending = pending - 1
+    if pending <= 0 then
+      paint_now()
     end
+  end
 
-    -- Warm path or already-painted cold path: re-render columns with fresh
-    -- data, skipping any column that owns its buffer via tree expansion.
-    local re_sessions = claude.get_all_sessions()
-    local tree = require("okuban.ui.tree")
-    for i, col in ipairs(fresh_cols) do
-      if not col._visible_items or not tree.has_any_expanded(i) then
-        local buf = self.buffers[i]
-        if buf and vim.api.nvim_buf_is_valid(buf) then
-          local iw = self:get_column_width(i) - 2
-          local lines, card_ranges = card.render_column(col.issues, iw, self.worktree_map, re_sessions, counts)
-          col.card_ranges = card_ranges
-          vim.bo[buf].modifiable = true
-          vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-          vim.bo[buf].modifiable = false
-
-          local win = self.windows[i]
-          if win and vim.api.nvim_win_is_valid(win) then
-            local title = format_title(col.name, #col.issues, col.limit)
-            vim.api.nvim_win_set_config(win, { title = title, title_pos = "center" })
-          end
-        end
-      end
-    end
-    self.columns = fresh_cols
-
-    if self.navigation then
-      self.navigation:clamp_position()
-      self.navigation:highlight_current()
-    end
+  worktree.fetch_enriched(function(em)
+    enriched_wt_map = em
+    on_async_done()
   end)
 
-  -- Cold-path safety net: if the GraphQL fetch hangs (network failure, gh
-  -- crash), fall back to an unfiltered first paint after 2s rather than
-  -- leaving the user stuck on the loading skeleton.
-  if cold_first_paint then
-    vim.defer_fn(function()
-      if self:is_open() and self.columns == nil then
-        self:_paint_columns(cols, layout, wt_map, sessions, self.sub_issue_counts)
-        self:_setup_or_update_navigation()
-      end
-    end, 2000)
+  if #all_numbers == 0 then
+    fresh_counts = {}
+    fresh_parent_map = {}
+    on_async_done()
+  else
+    api.fetch_sub_issue_counts(all_numbers, function(counts, pm)
+      fresh_counts = counts
+      fresh_parent_map = pm
+      on_async_done()
+    end)
   end
 
-  header.set_last_updated(os.time())
+  -- Safety net: if any fetch hangs (network failure, gh crash), paint with
+  -- whatever we have rather than leaving the user stuck. paint_now is
+  -- guarded by `painted` and the generation counter so a redundant call is
+  -- a no-op.
+  vim.defer_fn(paint_now, 2500)
 end
 
 --- Open the board with the given data (immediate, no loading phase).

--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -478,6 +478,12 @@ end
 --- Open the board with loading placeholders (instant skeleton).
 --- No navigation is set up — call populate(data) when data arrives.
 function Board:open_loading()
+  -- Idempotent: if windows already exist (e.g., a concurrent open() raced
+  -- ahead), bail rather than appending another set.
+  if self:is_open() then
+    return
+  end
+
   define_highlights()
 
   local cfg = config.get()

--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -574,6 +574,47 @@ function Board:open_loading()
   end
 
   self:_setup_autocommands()
+  self:_start_loading_animation()
+end
+
+--- Animated loading text frames (ASCII-only).
+local LOADING_FRAMES = { "Loading.  ", "Loading.. ", "Loading...", "Loading.. " }
+
+--- Start a buffer-text animation that cycles "Loading..." across all column
+--- buffers until the first paint replaces them. No-op if already running.
+function Board:_start_loading_animation()
+  if self._loading_timer then
+    return
+  end
+  local frame_idx = 1
+
+  local function render_frame()
+    if not self:is_open() or self.columns then
+      self:_stop_loading_animation()
+      return
+    end
+    local text = "  " .. LOADING_FRAMES[frame_idx]
+    for _, buf in ipairs(self.buffers) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        vim.bo[buf].modifiable = true
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { text })
+        vim.bo[buf].modifiable = false
+      end
+    end
+    frame_idx = (frame_idx % #LOADING_FRAMES) + 1
+  end
+
+  self._loading_timer = vim.uv.new_timer()
+  self._loading_timer:start(0, 250, vim.schedule_wrap(render_frame))
+end
+
+--- Stop the loading animation and free the timer. Idempotent.
+function Board:_stop_loading_animation()
+  if self._loading_timer then
+    self._loading_timer:stop()
+    self._loading_timer:close()
+    self._loading_timer = nil
+  end
 end
 
 --- Render the given column list to existing buffers, update window titles,
@@ -710,6 +751,7 @@ function Board:populate(data, on_painted)
       return
     end
     painted = true
+    self:_stop_loading_animation()
 
     local pm = fresh_parent_map or cached_parent_map or {}
     local final_cols = build_column_list(data)
@@ -1021,6 +1063,7 @@ end
 --- Close the board and clean up all windows and buffers.
 function Board:close()
   self:_stop_auto_refresh()
+  self:_stop_loading_animation()
   require("okuban.ui.tree").reset()
 
   if self.augroup then

--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -227,6 +227,31 @@ local function format_title(name, issue_count, limit)
   return string.format(" %s (%d) ", name, issue_count)
 end
 
+--- Drop sub-issues (issues whose number maps to a parent) from each column in place.
+---@param cols table[] Column list from build_column_list
+---@param parent_map table<integer, integer>|nil
+---@return boolean filtered_any True if at least one issue was removed
+local function filter_sub_issues_in_place(cols, parent_map)
+  if not parent_map or vim.tbl_isempty(parent_map) then
+    return false
+  end
+  local filtered_any = false
+  for _, col in ipairs(cols) do
+    local original_count = #col.issues
+    local filtered = {}
+    for _, issue in ipairs(col.issues) do
+      if not parent_map[issue.number] then
+        table.insert(filtered, issue)
+      end
+    end
+    if #filtered < original_count then
+      col.issues = filtered
+      filtered_any = true
+    end
+  end
+  return filtered_any
+end
+
 --- Create the preview window below the column windows.
 ---@param layout table Layout from calculate_layout
 function Board:_create_preview_window(layout)
@@ -551,6 +576,67 @@ function Board:open_loading()
   self:_setup_autocommands()
 end
 
+--- Render the given column list to existing buffers, update window titles,
+--- store columns on self, and apply active-worktree highlights.
+---@param cols table[]
+---@param layout table
+---@param wt_map table<integer, table>|nil
+---@param sessions table
+---@param counts table|nil sub-issue counts
+function Board:_paint_columns(cols, layout, wt_map, sessions, counts)
+  for i, col in ipairs(cols) do
+    local buf = self.buffers[i]
+    local win = self.windows[i]
+
+    if buf and vim.api.nvim_buf_is_valid(buf) then
+      local inner_width = layout.col_width - 2
+      local lines, card_ranges = card.render_column(col.issues, inner_width, wt_map, sessions, counts or {})
+      col.card_ranges = card_ranges
+
+      vim.bo[buf].modifiable = true
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+      vim.bo[buf].modifiable = false
+    end
+
+    if win and vim.api.nvim_win_is_valid(win) then
+      local title = format_title(col.name, #col.issues, col.limit)
+      vim.api.nvim_win_set_config(win, {
+        relative = "editor",
+        row = layout.start_row,
+        col = layout.start_col + (i - 1) * (layout.col_width + layout.gap),
+        width = layout.col_width,
+        height = layout.board_height,
+        title = title,
+        title_pos = "center",
+      })
+    end
+  end
+
+  self.columns = cols
+  self:_apply_active_highlights(wt_map)
+end
+
+--- Set up navigation for the first time or refresh it while preserving position.
+function Board:_setup_or_update_navigation()
+  local Navigation = require("okuban.ui.navigation")
+  if self.navigation then
+    local old_col = self.navigation.column_index
+    local old_card = self.navigation.card_index
+    local old_issue_mode = self.navigation.issue_mode
+    self.navigation = Navigation.new(self)
+    self.navigation.column_index = math.min(old_col, self.navigation:num_columns())
+    local count = self.navigation:card_count(self.navigation.column_index)
+    self.navigation.card_index = math.min(old_card, math.max(1, count))
+    self.navigation.issue_mode = old_issue_mode or false
+  else
+    self.navigation = Navigation.new(self)
+  end
+  for _, buf in ipairs(self.buffers) do
+    self.navigation:setup_keymaps(buf)
+  end
+  self.navigation:highlight_current()
+end
+
 --- Populate existing loading windows with real data in-place.
 --- Sets up navigation and full keymaps.
 ---@param data table Board data from api.fetch_all_columns
@@ -587,181 +673,132 @@ function Board:populate(data)
   self.worktree_map = wt_map
   local sessions = claude.get_all_sessions()
 
-  for i, col in ipairs(cols) do
-    local buf = self.buffers[i]
-    local win = self.windows[i]
-
-    if buf and vim.api.nvim_buf_is_valid(buf) then
-      local inner_width = layout.col_width - 2
-      local lines, card_ranges = card.render_column(col.issues, inner_width, wt_map, sessions, self.sub_issue_counts)
-      col.card_ranges = card_ranges
-
-      vim.bo[buf].modifiable = true
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-      vim.bo[buf].modifiable = false
-    end
-
-    -- Update window title with count
-    if win and vim.api.nvim_win_is_valid(win) then
-      local title = format_title(col.name, #col.issues, col.limit)
-      vim.api.nvim_win_set_config(win, {
-        relative = "editor",
-        row = layout.start_row,
-        col = layout.start_col + (i - 1) * (layout.col_width + layout.gap),
-        width = layout.col_width,
-        height = layout.board_height,
-        title = title,
-        title_pos = "center",
-      })
-    end
+  -- Apply cached parent_map filter pre-render so known sub-issues never flash.
+  local api = require("okuban.api")
+  local cached_parent_map = (api.get_cached_parent_map and api.get_cached_parent_map()) or nil
+  if cached_parent_map and not vim.tbl_isempty(cached_parent_map) then
+    filter_sub_issues_in_place(cols, cached_parent_map)
   end
 
-  self.columns = cols
+  -- Cold first paint: no cached parent_map AND no prior render means buffers
+  -- still hold the "Loading..." skeleton from open_loading(). Defer the first
+  -- paint until fresh parent_map arrives so sub-issues never appear at all.
+  local cold_first_paint = self.columns == nil and cached_parent_map == nil
 
-  -- Apply orange highlight to active worktree cards
-  self:_apply_active_highlights(wt_map)
+  if not cold_first_paint then
+    self:_paint_columns(cols, layout, wt_map, sessions, self.sub_issue_counts)
+    self:_setup_or_update_navigation()
+  end
 
-  -- Enrich worktree map with dirty/clean status asynchronously
+  -- Async: enrich worktree map with dirty/clean status. Skips if buffers
+  -- haven't been painted yet (cold path); the post-fetch_sub_issue_counts
+  -- paint will own the first render and worktree enrichment will overlay
+  -- once it completes (or already has, via self.worktree_map below).
   worktree.fetch_enriched(function(enriched_map)
     if not self:is_open() then
       return
     end
     self.worktree_map = enriched_map
-    -- Re-render columns with dirty/clean badges
+    if not self.columns then
+      return
+    end
+    local re_sessions = claude.get_all_sessions()
     for i, col in ipairs(self.columns) do
       local buf = self.buffers[i]
       if buf and vim.api.nvim_buf_is_valid(buf) then
         local inner_width = layout.col_width - 2
         local lines, card_ranges =
-          card.render_column(col.issues, inner_width, enriched_map, sessions, self.sub_issue_counts)
+          card.render_column(col.issues, inner_width, enriched_map, re_sessions, self.sub_issue_counts)
         col.card_ranges = card_ranges
         vim.bo[buf].modifiable = true
         vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
         vim.bo[buf].modifiable = false
       end
     end
-    -- Re-apply active highlights after re-rendering
     self:_apply_active_highlights(enriched_map)
-    -- Re-highlight current card and update preview
     if self.navigation then
       self.navigation:highlight_current()
     end
   end)
 
-  -- Fetch sub-issue counts asynchronously
+  -- Async: fresh sub-issue counts + parent_map.
+  --   Cold path: this triggers the first paint with the filter applied.
+  --   Warm path: re-renders if parent_map changed and updates badges with counts.
   local all_numbers = {}
-  for _, col in ipairs(cols) do
-    for _, issue in ipairs(col.issues) do
+  for _, raw_col in ipairs(build_column_list(data)) do
+    for _, issue in ipairs(raw_col.issues) do
       table.insert(all_numbers, issue.number)
     end
   end
-  if #all_numbers > 0 then
-    local api = require("okuban.api")
-    api.fetch_sub_issue_counts(all_numbers, function(counts, parent_map)
-      if not self:is_open() then
-        return
-      end
 
-      -- Filter sub-issues from the board (label mode only).
-      -- Issues that have a parent are sub-issues and should only appear
-      -- in the tree view, not as standalone cards on the board.
-      local filtered_any = false
-      if parent_map and not vim.tbl_isempty(parent_map) then
-        for i, col in ipairs(self.columns) do
-          local original_count = #col.issues
-          local filtered = {}
-          for _, issue in ipairs(col.issues) do
-            if not parent_map[issue.number] then
-              table.insert(filtered, issue)
-            end
-          end
-          if #filtered < original_count then
-            col.issues = filtered
-            filtered_any = true
-            -- Update column title with new count
-            local win = self.windows[i]
-            if win and vim.api.nvim_win_is_valid(win) then
-              local title = format_title(col.name, #col.issues, col.limit)
-              vim.api.nvim_win_set_config(win, { title = title, title_pos = "center" })
-            end
-          end
-        end
-      end
-
-      if not counts or vim.tbl_isempty(counts) then
-        if filtered_any then
-          -- Still need to re-render even without counts, since we removed cards
-          local re_sessions = claude.get_all_sessions()
-          local tree = require("okuban.ui.tree")
-          for i, col in ipairs(self.columns) do
-            if not col._visible_items or not tree.has_any_expanded(i) then
-              local buf = self.buffers[i]
-              if buf and vim.api.nvim_buf_is_valid(buf) then
-                local iw = self:get_column_width(i) - 2
-                local lines, card_ranges =
-                  card.render_column(col.issues, iw, self.worktree_map, re_sessions, self.sub_issue_counts)
-                col.card_ranges = card_ranges
-                vim.bo[buf].modifiable = true
-                vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-                vim.bo[buf].modifiable = false
-              end
-            end
-          end
-          if self.navigation then
-            self.navigation:clamp_position()
-            self.navigation:highlight_current()
-          end
-        end
-        return
-      end
-
-      self.sub_issue_counts = counts
-      -- Re-render columns with sub-issue badges (skip tree-expanded columns)
-      local re_sessions = claude.get_all_sessions()
-      local tree = require("okuban.ui.tree")
-      for i, col in ipairs(self.columns) do
-        -- Skip columns that have an active tree expansion (tree owns their buffer content)
-        if not col._visible_items or not tree.has_any_expanded(i) then
-          local buf = self.buffers[i]
-          if buf and vim.api.nvim_buf_is_valid(buf) then
-            local iw = self:get_column_width(i) - 2
-            local lines, card_ranges = card.render_column(col.issues, iw, self.worktree_map, re_sessions, counts)
-            col.card_ranges = card_ranges
-            vim.bo[buf].modifiable = true
-            vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-            vim.bo[buf].modifiable = false
-          end
-        end
-      end
-      if self.navigation then
-        if filtered_any then
-          self.navigation:clamp_position()
-        end
-        self.navigation:highlight_current()
-      end
-    end)
+  if #all_numbers == 0 then
+    if cold_first_paint and self.columns == nil then
+      self:_paint_columns(cols, layout, wt_map, sessions, self.sub_issue_counts)
+      self:_setup_or_update_navigation()
+    end
+    header.set_last_updated(os.time())
+    return
   end
 
-  -- Set up or update navigation, preserving position during refresh
-  local Navigation = require("okuban.ui.navigation")
-  if self.navigation then
-    local old_col = self.navigation.column_index
-    local old_card = self.navigation.card_index
-    local old_issue_mode = self.navigation.issue_mode
-    self.navigation = Navigation.new(self)
-    self.navigation.column_index = math.min(old_col, self.navigation:num_columns())
-    local count = self.navigation:card_count(self.navigation.column_index)
-    self.navigation.card_index = math.min(old_card, math.max(1, count))
-    self.navigation.issue_mode = old_issue_mode or false
-  else
-    self.navigation = Navigation.new(self)
-  end
-  for _, buf in ipairs(self.buffers) do
-    self.navigation:setup_keymaps(buf)
-  end
-  self.navigation:highlight_current()
+  api.fetch_sub_issue_counts(all_numbers, function(counts, fresh_parent_map)
+    if not self:is_open() then
+      return
+    end
 
-  -- Record update timestamp for staleness indicator
+    local fresh_cols = build_column_list(data)
+    filter_sub_issues_in_place(fresh_cols, fresh_parent_map or {})
+    self.sub_issue_counts = counts or {}
+
+    if self.columns == nil then
+      -- Cold path: first paint.
+      self:_paint_columns(fresh_cols, layout, self.worktree_map, claude.get_all_sessions(), counts)
+      self:_setup_or_update_navigation()
+      return
+    end
+
+    -- Warm path or already-painted cold path: re-render columns with fresh
+    -- data, skipping any column that owns its buffer via tree expansion.
+    local re_sessions = claude.get_all_sessions()
+    local tree = require("okuban.ui.tree")
+    for i, col in ipairs(fresh_cols) do
+      if not col._visible_items or not tree.has_any_expanded(i) then
+        local buf = self.buffers[i]
+        if buf and vim.api.nvim_buf_is_valid(buf) then
+          local iw = self:get_column_width(i) - 2
+          local lines, card_ranges = card.render_column(col.issues, iw, self.worktree_map, re_sessions, counts)
+          col.card_ranges = card_ranges
+          vim.bo[buf].modifiable = true
+          vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+          vim.bo[buf].modifiable = false
+
+          local win = self.windows[i]
+          if win and vim.api.nvim_win_is_valid(win) then
+            local title = format_title(col.name, #col.issues, col.limit)
+            vim.api.nvim_win_set_config(win, { title = title, title_pos = "center" })
+          end
+        end
+      end
+    end
+    self.columns = fresh_cols
+
+    if self.navigation then
+      self.navigation:clamp_position()
+      self.navigation:highlight_current()
+    end
+  end)
+
+  -- Cold-path safety net: if the GraphQL fetch hangs (network failure, gh
+  -- crash), fall back to an unfiltered first paint after 2s rather than
+  -- leaving the user stuck on the loading skeleton.
+  if cold_first_paint then
+    vim.defer_fn(function()
+      if self:is_open() and self.columns == nil then
+        self:_paint_columns(cols, layout, wt_map, sessions, self.sub_issue_counts)
+        self:_setup_or_update_navigation()
+      end
+    end, 2000)
+  end
+
   header.set_last_updated(os.time())
 end
 
@@ -794,6 +831,13 @@ function Board:open(data)
   local wt_map = worktree.fetch_worktree_map()
   self.worktree_map = wt_map
   local sessions = claude.get_all_sessions()
+
+  -- Apply cached parent_map filter pre-render (warm path; matches populate).
+  local api_module = require("okuban.api")
+  local cached_parent_map = (api_module.get_cached_parent_map and api_module.get_cached_parent_map()) or nil
+  if cached_parent_map and not vim.tbl_isempty(cached_parent_map) then
+    filter_sub_issues_in_place(cols, cached_parent_map)
+  end
 
   for i, col in ipairs(cols) do
     local buf = vim.api.nvim_create_buf(false, true)

--- a/tests/test_api_fetch_spec.lua
+++ b/tests/test_api_fetch_spec.lua
@@ -471,6 +471,103 @@ describe("okuban.api fetch", function()
     end)
   end)
 
+  describe("get_cached_parent_map", function()
+    before_each(function()
+      local api_labels = require("okuban.api_labels")
+      api_labels._reset_parent_map_cache()
+      api._reset_repo_info()
+    end)
+
+    it("returns nil before any fetch_sub_issue_counts call", function()
+      local api_labels = require("okuban.api_labels")
+      assert.is_nil(api_labels.get_cached_parent_map())
+      assert.is_nil(api.get_cached_parent_map())
+    end)
+
+    it("populates after fetch_sub_issue_counts resolves", function()
+      local graphql_response = vim.json.encode({
+        data = {
+          repository = {
+            i10 = { subIssuesSummary = { total = 2, completed = 0 }, parent = vim.NIL },
+            i11 = { subIssuesSummary = { total = 0, completed = 0 }, parent = { number = 10 } },
+          },
+        },
+      })
+      helpers.mock_vim_system({
+        { code = 0, stdout = "alice|myrepo" },
+        { code = 0, stdout = graphql_response },
+      })
+
+      local api_labels = require("okuban.api_labels")
+
+      local done = false
+      api_labels.fetch_sub_issue_counts({ 10, 11 }, function()
+        done = true
+      end)
+      vim.wait(2000, function()
+        return done
+      end)
+
+      local cached = api_labels.get_cached_parent_map()
+      assert.is_not_nil(cached)
+      assert.equals(10, cached[11])
+      assert.is_nil(cached[10])
+      -- The api.lua proxy returns the same cache in label mode
+      assert.equals(cached, api.get_cached_parent_map())
+    end)
+
+    it("overwrites cache on subsequent fetches", function()
+      local first_response = vim.json.encode({
+        data = {
+          repository = {
+            i10 = { subIssuesSummary = { total = 1, completed = 0 }, parent = vim.NIL },
+            i11 = { subIssuesSummary = { total = 0, completed = 0 }, parent = { number = 10 } },
+          },
+        },
+      })
+      -- Second response: issue 11 is no longer a sub-issue (parent removed)
+      local second_response = vim.json.encode({
+        data = {
+          repository = {
+            i10 = { subIssuesSummary = { total = 0, completed = 0 }, parent = vim.NIL },
+            i11 = { subIssuesSummary = { total = 0, completed = 0 }, parent = vim.NIL },
+          },
+        },
+      })
+      helpers.mock_vim_system({
+        { code = 0, stdout = "alice|myrepo" },
+        { code = 0, stdout = first_response },
+        { code = 0, stdout = second_response },
+      })
+
+      local api_labels = require("okuban.api_labels")
+
+      local done1 = false
+      api_labels.fetch_sub_issue_counts({ 10, 11 }, function()
+        done1 = true
+      end)
+      vim.wait(2000, function()
+        return done1
+      end)
+      assert.equals(10, api_labels.get_cached_parent_map()[11])
+
+      local done2 = false
+      api_labels.fetch_sub_issue_counts({ 10, 11 }, function()
+        done2 = true
+      end)
+      vim.wait(2000, function()
+        return done2
+      end)
+      -- Cache reflects the new state: no parents
+      assert.is_nil(api_labels.get_cached_parent_map()[11])
+    end)
+
+    it("api.get_cached_parent_map returns nil in project mode", function()
+      config.setup({ source = "project" })
+      assert.is_nil(api.get_cached_parent_map())
+    end)
+  end)
+
   describe("fetch_sub_issues", function()
     it("parses GraphQL response into sub-issue array", function()
       local graphql_response = vim.json.encode({


### PR DESCRIPTION
## Summary

Eliminates the multi-paint flicker on board open. The board now waits for **all** async data (column issues, worktree enrichment, sub-issue counts + parent_map) before painting. One render, no transitions through intermediate states.

### What was flickering

Before this PR, `Board:populate` painted up to three times:
1. **Initial render** (sync, immediately on populate): all issues including sub-issues, no worktree dirty/clean badges, no sub-issue counts.
2. **Worktree enrichment** (async, ~50-300ms): flipped cards in with ○/● badges and `OkubanCardActive` highlights.
3. **Sub-issue counts + parent_map** (async, ~200-500ms): added `n/m` sub-issue badges and pruned sub-issues from the top level.

The visible result: cards popped in unfiltered, badges fluttered in over the next ~500ms, and known sub-issues (e.g. `khw_web` `#60`/`#24`) flashed before vanishing.

### What changed

**`api_labels`** — caches `parent_map` across the session. `get_cached_parent_map()` exposes it as a fallback when fresh GraphQL hangs.

**`board`** — `Board:populate` is now a single async barrier:
- Sync setup (validation, layout, `worktree.fetch_worktree_map` baseline).
- Both `worktree.fetch_enriched` and `fetch_sub_issue_counts` fire in parallel.
- `populate` returns immediately; the buffers keep their prior content (loading skeleton on cold open, previous cards on refresh).
- When both fetches resolve, `paint_now` runs once with the freshest data — filter applied, badges set, highlights applied.
- 2.5s safety net falls back to whatever data has arrived if any fetch hangs.
- Generation counter (`self._populate_gen`) invalidates stale async chains so a slow first refresh cannot overwrite a faster second refresh.

**`init`** — `_populate_board` passes auto-focus as an `on_painted` callback so it fires after navigation is set up rather than racing the paint.

**`board:open`** also applies the cached parent_map filter for consistency in the column-mismatch fallback path.

Two new helpers (`Board:_paint_columns`, `Board:_setup_or_update_navigation`) keep the paint logic readable.

### Tradeoff

Cold first open now waits ~300-700ms (the longer of `gh issue list` + `max(fetch_enriched, fetch_sub_issue_counts)`) before any cards appear. The loading skeleton stays visible during this wait. Refresh keeps the previous cards visible until the new render is ready, so refreshes look like a single snap rather than a flicker storm.

## Test plan

- [ ] Cold open in `khw_web`: loading skeleton stays visible, then cards appear in one paint with worktree badges and sub-issue counts already correct
- [ ] Warm reopen in same nvim session: same single-paint behaviour, just faster (parent_map cache hit)
- [ ] Refresh while on a card: old cards stay visible until new render snaps in; cursor/preview keep working during the wait
- [ ] Auto-focus: `g`-detected current issue is highlighted on open
- [ ] Network failure on GraphQL: 2.5s timeout falls back to render with whatever arrived
- [ ] `make check` clean (StyLua + Luacheck + plenary)
- [ ] 4 new unit tests for `get_cached_parent_map` cache lifecycle

Fixes #154