### PR TITLE
fix(tmux): popup loses cwd, preflight fails with "Cannot access repository"

### DIFF
--- a/lua/okuban/tmux.lua
+++ b/lua/okuban/tmux.lua
@@ -184,6 +184,9 @@ end
 
 --- Build the tmux display-popup command to open okuban in a floating overlay.
 --- Sets OKUBAN_POPUP=1 so the board knows to quit Neovim on close.
+--- Passes -d with Neovim's cwd so the popup nvim starts in the same directory
+--- as the parent — tmux's pane_current_path can resolve to $HOME on macOS,
+--- which would make the popup's preflight fail outside a git repo.
 ---@param opts { width?: string, height?: string }|nil
 ---@return string[] cmd
 function M.build_popup_command(opts)
@@ -193,6 +196,8 @@ function M.build_popup_command(opts)
   return {
     "tmux",
     "display-popup",
+    "-d",
+    vim.fn.getcwd(),
     "-xC",
     "-yC",
     "-w",

--- a/tests/test_tmux_spec.lua
+++ b/tests/test_tmux_spec.lua
@@ -35,37 +35,57 @@ describe("okuban.tmux", function()
   end)
 
   describe("build_popup_command", function()
+    --- Find the value following the first occurrence of `flag` in cmd.
+    local function arg_after(cmd, flag)
+      for i, v in ipairs(cmd) do
+        if v == flag then
+          return cmd[i + 1]
+        end
+      end
+      return nil
+    end
+
     it("builds display-popup command with defaults", function()
       local cmd = tmux.build_popup_command()
       assert.are.equal("tmux", cmd[1])
       assert.are.equal("display-popup", cmd[2])
-      assert.are.equal("-xC", cmd[3])
-      assert.are.equal("-yC", cmd[4])
-      assert.are.equal("-w", cmd[5])
-      assert.are.equal("90%", cmd[6])
-      assert.are.equal("-h", cmd[7])
-      assert.are.equal("90%", cmd[8])
-      assert.are.equal("-e", cmd[9])
-      assert.are.equal("OKUBAN_POPUP=1", cmd[10])
-      assert.are.equal("-E", cmd[11])
-      assert.are.equal("nvim +Okuban", cmd[12])
+      assert.are.equal("90%", arg_after(cmd, "-w"))
+      assert.are.equal("90%", arg_after(cmd, "-h"))
+      assert.are.equal("OKUBAN_POPUP=1", arg_after(cmd, "-e"))
+      assert.are.equal("nvim +Okuban", arg_after(cmd, "-E"))
+      -- Position flags (no arg)
+      local has_xC, has_yC = false, false
+      for _, v in ipairs(cmd) do
+        if v == "-xC" then
+          has_xC = true
+        end
+        if v == "-yC" then
+          has_yC = true
+        end
+      end
+      assert.is_true(has_xC, "expected -xC in command")
+      assert.is_true(has_yC, "expected -yC in command")
     end)
 
     it("respects custom width and height", function()
       local cmd = tmux.build_popup_command({ width = "80%", height = "70%" })
-      assert.are.equal("80%", cmd[6])
-      assert.are.equal("70%", cmd[8])
+      assert.are.equal("80%", arg_after(cmd, "-w"))
+      assert.are.equal("70%", arg_after(cmd, "-h"))
     end)
 
     it("sets OKUBAN_POPUP=1 env var", function()
       local cmd = tmux.build_popup_command()
-      local found = false
-      for i, v in ipairs(cmd) do
-        if v == "-e" and cmd[i + 1] == "OKUBAN_POPUP=1" then
-          found = true
-        end
+      assert.are.equal("OKUBAN_POPUP=1", arg_after(cmd, "-e"))
+    end)
+
+    it("passes -d with Neovim's cwd so popup inherits it (regression: #156)", function()
+      local orig_getcwd = vim.fn.getcwd
+      vim.fn.getcwd = function()
+        return "/tmp/okuban-fixture-repo"
       end
-      assert.is_true(found, "expected -e OKUBAN_POPUP=1 in command")
+      local cmd = tmux.build_popup_command()
+      vim.fn.getcwd = orig_getcwd
+      assert.are.equal("/tmp/okuban-fixture-repo", arg_after(cmd, "-d"))
     end)
   end)
 


### PR DESCRIPTION
## Summary
- Fix `:Okuban` failing in tmux with "Cannot access repository" when the parent Neovim's cwd is a valid GitHub repo.
- `lua/okuban/tmux.lua:M.build_popup_command` now passes `-d vim.fn.getcwd()` so the popup `nvim +Okuban` inherits the parent's cwd instead of relying on tmux's `pane_current_path` (which on macOS can resolve to `$HOME`).
- Refactor the popup-builder test from positional indices to flag-lookup assertions so future flag additions don't break the test, and add a regression test for `-d`.

Fixes #156

## Repro (before)
From `nvim` launched in a valid GitHub repo inside tmux:
```vim
:Okuban
" => okuban: Cannot access repository. Ensure you are in a git repo with a GitHub remote
```

```vim
:lua vim.system({"tmux","display-popup","-E","pwd > /tmp/x.txt"},{text=true}):wait()
:!cat /tmp/x.txt
" => /Users/<me>     (home dir, not the repo)
```

Setting `tmux.prefer_popup = false` and re-running `:Okuban` worked, isolating the regression to the popup launch path.

## Test plan
- [x] `make check` — StyLua + Luacheck + plenary tests on stable
- [x] New test `passes -d with Neovim's cwd so popup inherits it (regression: #156)` asserts the flag is present with the stubbed cwd
- [x] Existing `tests/test_tmux_spec.lua` (49 tests) all pass after the assertion-style refactor
- [ ] Manual smoke: open `nvim` in a repo inside tmux, run `:Okuban`, board opens