### PR TITLE
fix(ui): always include Unsorted column when show_unsorted=true (Fixes #158)

### DIFF
--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -202,6 +202,11 @@ function Board.new()
 end
 
 --- Build the column list for display from board data.
+--- Always emits the Unsorted column when `data.unsorted` is set (i.e.
+--- `show_unsorted = true`), even if empty. Matches `open_loading`'s window
+--- count so `populate` does not fall back to the synchronous `Board:open`
+--- path, which would skip the async parent_map fetch and leave sub-issues
+--- unfiltered.
 ---@param data table Board data from api.fetch_all_columns
 ---@return table[] cols
 local function build_column_list(data)
@@ -209,7 +214,7 @@ local function build_column_list(data)
   for _, col in ipairs(data.columns) do
     table.insert(cols, { name = col.name, issues = col.issues, limit = col.limit, has_more = col.has_more })
   end
-  if data.unsorted and #data.unsorted > 0 then
+  if data.unsorted then
     table.insert(cols, { name = "Unsorted", issues = data.unsorted })
   end
   return cols
@@ -1144,5 +1149,7 @@ function Board.close_instance()
     instance:close()
   end
 end
+
+Board._build_column_list = build_column_list
 
 return Board

--- a/tests/test_board_layout_spec.lua
+++ b/tests/test_board_layout_spec.lua
@@ -277,4 +277,64 @@ describe("okuban.ui.board layout", function()
       assert.is_true(total <= board_width)
     end)
   end)
+
+  describe("_build_column_list", function()
+    -- Regression: when show_unsorted=true the board reserves an Unsorted window
+    -- in open_loading regardless of issue count. build_column_list must agree so
+    -- populate's column-count check (#cols == #self.windows) does not fall back
+    -- to the synchronous Board:open path, which skips the async parent_map
+    -- fetch and leaves sub-issues unfiltered. (Fixes #158)
+    it("includes Unsorted column when data.unsorted is an empty table", function()
+      local data = {
+        columns = {
+          { name = "Backlog", issues = {}, limit = 100 },
+          { name = "Todo", issues = {}, limit = 100 },
+        },
+        unsorted = {},
+      }
+      local cols = Board._build_column_list(data)
+      assert.equals(3, #cols)
+      assert.equals("Unsorted", cols[3].name)
+      assert.same({}, cols[3].issues)
+    end)
+
+    it("includes Unsorted column when data.unsorted has issues", function()
+      local data = {
+        columns = {
+          { name = "Backlog", issues = {}, limit = 100 },
+        },
+        unsorted = { { number = 99, title = "Stray" } },
+      }
+      local cols = Board._build_column_list(data)
+      assert.equals(2, #cols)
+      assert.equals("Unsorted", cols[2].name)
+      assert.equals(1, #cols[2].issues)
+    end)
+
+    it("omits Unsorted column when data.unsorted is nil (show_unsorted=false)", function()
+      local data = {
+        columns = {
+          { name = "Backlog", issues = {}, limit = 100 },
+          { name = "Todo", issues = {}, limit = 100 },
+        },
+        -- data.unsorted is nil — fetch_all_columns omits the field entirely
+        -- when config.show_unsorted is false.
+      }
+      local cols = Board._build_column_list(data)
+      assert.equals(2, #cols)
+      assert.equals("Backlog", cols[1].name)
+      assert.equals("Todo", cols[2].name)
+    end)
+
+    it("preserves limit and has_more flags from configured columns", function()
+      local data = {
+        columns = {
+          { name = "Backlog", issues = {}, limit = 50, has_more = true },
+        },
+      }
+      local cols = Board._build_column_list(data)
+      assert.equals(50, cols[1].limit)
+      assert.is_true(cols[1].has_more)
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary

- Fixes the cold-open bug where sub-issues appeared as top-level cards on repos that fully label their issues with `okuban:` prefixes (zero unsorted).
- Surgical 1-line change in `build_column_list`: always emit the Unsorted column when `data.unsorted` is set, even if empty — matches `open_loading`'s window count so `populate`'s async parent_map filter runs reliably instead of falling back to the synchronous `Board:open` path.

## Root cause

`open_loading` reserves `#columns + (show_unsorted and 1 or 0)` windows. `build_column_list` only appended the Unsorted column when `#data.unsorted > 0`. On a fully-labeled repo, that left `#cols < #self.windows`, triggering the close+open fallback at `board.lua:700`. `Board:open` only consults the cached parent_map (nil on cold session) and never fires the async GraphQL fetch, so sub-issues rendered unfiltered.

## Behavior change

Users with `show_unsorted = true` (the default) now see an explicit `Unsorted (0)` column on fully-labeled repos. This is consistent with what `open_loading` already shows during the loading skeleton and surfaces the column for when an unlabeled issue eventually arrives.

`show_unsorted = false` is unchanged — `data.unsorted` is nil in that case and no Unsorted column is emitted.

Fix applies to both label mode and project mode (both pass `data.unsorted = {}` when `show_unsorted=true`).

## Test plan

- [x] `make check` (StyLua + Luacheck + plenary tests on stable) — 0 warnings, 0 failures.
- [x] 4 new regression tests in `tests/test_board_layout_spec.lua`:
  - Includes Unsorted column when `data.unsorted = {}`
  - Includes Unsorted column when `data.unsorted` has issues
  - Omits Unsorted column when `data.unsorted` is nil
  - Preserves `limit` / `has_more` flags from configured columns
- [ ] CI: Lint, Test (stable), Test (nightly)
- [ ] Manual: open board against `khwerhahn/tactus` (zero unsorted, real GitHub sub-issues #16–#20 under #5, #6–#12 under #4) — Backlog should now show only #4 instead of 10 unfiltered sub-issues.

Fixes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)