### PR TITLE
fix(ui): drop leaf sub-issues + auto-fetch missing parents (Fixes #160)

### DIFF
--- a/lua/okuban/api.lua
+++ b/lua/okuban/api.lua
@@ -237,6 +237,18 @@ function M.fetch_sub_issues(parent_number, callback)
   return require("okuban.api_labels").fetch_sub_issues(parent_number, callback)
 end
 
+--- Batch-fetch full issue details by number (label-mode only).
+--- Used to pull in parent issues that fell outside `initial_fetch_limit`.
+---@param issue_numbers integer[]
+---@param callback fun(issues: table[], new_parents: table<integer,integer>, new_counts: table)
+function M.fetch_issue_details(issue_numbers, callback)
+  if config.get().source == "project" then
+    callback({}, {}, {})
+    return
+  end
+  return require("okuban.api_labels").fetch_issue_details(issue_numbers, callback)
+end
+
 --- Return the cached parent_map (label-mode only).
 --- Returns nil if never fetched or in project mode.
 ---@return table<integer, integer>|nil

--- a/lua/okuban/api_labels.lua
+++ b/lua/okuban/api_labels.lua
@@ -403,6 +403,139 @@ function M._reset_parent_map_cache()
 end
 
 -- ---------------------------------------------------------------------------
+-- Issue details by number (used to fetch parents outside fetch limit)
+-- ---------------------------------------------------------------------------
+
+--- Batch-fetch full issue details by issue number.
+--- Used to fetch parent issues that fall outside `initial_fetch_limit`
+--- (e.g. an epic whose children are more recently updated than the epic
+--- itself) so the kanban can show them as top-level cards.
+---
+--- Issues are returned in the gh-CLI-shape compatible with the rest of
+--- the plugin: `{ number, title, body, state, updatedAt, createdAt,
+--- labels = [{ name, color, description }], assignees = [{ login }] }`.
+--- Also returns the parent and sub-issue-count entries discovered during
+--- the fetch so callers can extend their maps for transitive lookups.
+---@param issue_numbers integer[]
+---@param callback fun(issues: table[], new_parents: table<integer,integer>, new_counts: table)
+function M.fetch_issue_details(issue_numbers, callback)
+  if not issue_numbers or #issue_numbers == 0 then
+    callback({}, {}, {})
+    return
+  end
+
+  local api = require("okuban.api")
+  api.detect_repo_info(function(owner, name)
+    if not owner or not name then
+      callback({}, {}, {})
+      return
+    end
+
+    local all_issues = {}
+    local all_parents = {}
+    local all_counts = {}
+    local chunks = {}
+    for i = 1, #issue_numbers, 25 do
+      local chunk = {}
+      for j = i, math.min(i + 24, #issue_numbers) do
+        table.insert(chunk, issue_numbers[j])
+      end
+      table.insert(chunks, chunk)
+    end
+
+    local pending = #chunks
+    if pending == 0 then
+      callback({}, {}, {})
+      return
+    end
+
+    for _, chunk in ipairs(chunks) do
+      local aliases = {}
+      for _, num in ipairs(chunk) do
+        table.insert(
+          aliases,
+          string.format(
+            "i%d: issue(number: %d) { number title body state updatedAt createdAt "
+              .. "labels(first: 20) { nodes { name color description } } "
+              .. "assignees(first: 5) { nodes { login } } "
+              .. "parent { number } subIssuesSummary { total completed } }",
+            num,
+            num
+          )
+        )
+      end
+      local query =
+        string.format('{ repository(owner: "%s", name: "%s") { %s } }', owner, name, table.concat(aliases, " "))
+
+      local cmd = vim.list_extend(vim.deepcopy(gh_base_cmd()), {
+        "api",
+        "graphql",
+        "-H",
+        "GraphQL-Features: sub_issues",
+        "-f",
+        "query=" .. query,
+      })
+
+      vim.system(cmd, { text = true }, function(result)
+        vim.schedule(function()
+          if result.code == 0 and result.stdout then
+            local ok, data = pcall(vim.json.decode, result.stdout)
+            if ok and data and data.data and data.data.repository then
+              local repo = data.data.repository
+              for _, num in ipairs(chunk) do
+                local entry = repo["i" .. num]
+                if entry and entry.number then
+                  local labels = {}
+                  if entry.labels and entry.labels.nodes then
+                    for _, l in ipairs(entry.labels.nodes) do
+                      table.insert(labels, l)
+                    end
+                  end
+                  local assignees = {}
+                  if entry.assignees and entry.assignees.nodes then
+                    for _, a in ipairs(entry.assignees.nodes) do
+                      table.insert(assignees, a)
+                    end
+                  end
+                  local body = entry.body
+                  if body == vim.NIL then
+                    body = ""
+                  end
+                  table.insert(all_issues, {
+                    number = entry.number,
+                    title = entry.title,
+                    body = body or "",
+                    state = entry.state,
+                    updatedAt = entry.updatedAt,
+                    createdAt = entry.createdAt,
+                    labels = labels,
+                    assignees = assignees,
+                  })
+                  if entry.parent and entry.parent ~= vim.NIL and entry.parent.number then
+                    all_parents[entry.number] = entry.parent.number
+                  end
+                  if entry.subIssuesSummary and entry.subIssuesSummary.total and entry.subIssuesSummary.total > 0 then
+                    all_counts[entry.number] = {
+                      total = entry.subIssuesSummary.total,
+                      completed = entry.subIssuesSummary.completed or 0,
+                    }
+                  end
+                end
+              end
+            end
+          end
+
+          pending = pending - 1
+          if pending == 0 then
+            callback(all_issues, all_parents, all_counts)
+          end
+        end)
+      end)
+    end
+  end)
+end
+
+-- ---------------------------------------------------------------------------
 -- Sub-issue details
 -- ---------------------------------------------------------------------------
 

--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -717,17 +717,48 @@ end
 ---@param parent_map table<integer, integer> Mutated; new entries added
 ---@param counts table<integer, {total: integer, completed: integer}> Mutated
 ---@param callback fun()
-local function inject_missing_parents(data, parent_map, counts, callback)
+---@param should_cancel fun(): boolean|nil Optional. Return true to abort the
+---  iterative fetch chain (e.g. a fresher populate has invalidated this run).
+---  When triggered, the callback still fires so the outer barrier resolves.
+local function inject_missing_parents(data, parent_map, counts, callback, should_cancel)
   local MAX_DEPTH = 5
   local depth = 0
-  local label_to_col = {}
-  for col_idx, col in ipairs(data.columns) do
-    if col.label then
-      label_to_col[col.label] = col_idx
+
+  -- Use the column ORDER from data, not a label→idx map, so a parent that
+  -- carries multiple okuban: labels is placed deterministically into the
+  -- first matching column (typically Backlog → Todo → In Progress → Review
+  -- → Done by default config). Avoids relying on label iteration order.
+  local function find_target_col(parent)
+    local parent_labels = {}
+    for _, label in ipairs(parent.labels or {}) do
+      parent_labels[label.name] = true
     end
+    for col_idx, col in ipairs(data.columns) do
+      if col.label and parent_labels[col.label] then
+        return col_idx
+      end
+    end
+    return nil
+  end
+
+  local function finalize()
+    -- Re-sort each column so injected parents land in the right position
+    -- per the configured sort (default: updatedAt desc).
+    local api_labels = require("okuban.api_labels")
+    if api_labels.sort_issues then
+      for _, col in ipairs(data.columns) do
+        api_labels.sort_issues(col.issues)
+      end
+    end
+    callback()
   end
 
   local function step()
+    if should_cancel and should_cancel() then
+      callback()
+      return
+    end
+
     local visible = {}
     for _, col in ipairs(data.columns) do
       for _, issue in ipairs(col.issues) do
@@ -751,36 +782,26 @@ local function inject_missing_parents(data, parent_map, counts, callback)
       table.insert(missing_list, num)
     end
     if #missing_list == 0 or depth >= MAX_DEPTH then
-      -- Re-sort each column so injected parents land in the right position
-      -- per the configured sort (default: updatedAt desc).
-      local api_labels = require("okuban.api_labels")
-      if api_labels.sort_issues then
-        for _, col in ipairs(data.columns) do
-          api_labels.sort_issues(col.issues)
-        end
-      end
-      callback()
+      finalize()
       return
     end
     depth = depth + 1
 
     local api = require("okuban.api")
     api.fetch_issue_details(missing_list, function(parents, new_parents, new_counts)
+      if should_cancel and should_cancel() then
+        callback()
+        return
+      end
       for _, parent in ipairs(parents) do
-        local placed = false
-        for _, label in ipairs(parent.labels or {}) do
-          local target = label_to_col[label.name]
-          if target and data.columns[target] then
-            table.insert(data.columns[target].issues, parent)
-            placed = true
-            break
-          end
+        local target = find_target_col(parent)
+        if target then
+          table.insert(data.columns[target].issues, parent)
         end
         -- Parent with no matching okuban: label is intentionally not
         -- injected: it would have no home column. Its children remain
         -- hidden by the leaf filter and unreachable from the board,
         -- which is the user's responsibility to fix (label the parent).
-        local _ = placed
       end
       for k, v in pairs(new_parents) do
         parent_map[k] = v
@@ -913,11 +934,16 @@ function Board:populate(data, on_painted)
       -- `initial_fetch_limit`. Each newly-injected parent is appended to
       -- `data.columns[i].issues` based on its okuban: label, so the leaf
       -- filter has a complete picture of which parents are on the board.
+      -- The should_cancel predicate short-circuits the iterative fetch
+      -- chain when a fresher populate run has invalidated this one,
+      -- preventing stale mutations to `data.columns`.
       inject_missing_parents(data, fresh_parent_map, fresh_counts, function()
         if self._populate_gen ~= gen then
           return
         end
         on_async_done()
+      end, function()
+        return self._populate_gen ~= gen
       end)
     end)
   end

--- a/lua/okuban/ui/board.lua
+++ b/lua/okuban/ui/board.lua
@@ -232,12 +232,25 @@ local function format_title(name, issue_count, limit)
   return string.format(" %s (%d) ", name, issue_count)
 end
 
---- Drop sub-issues (issues whose number maps to a parent) from each column in place.
+--- Drop leaf sub-issues from each column in place. An issue is a leaf
+--- sub-issue when it has a GitHub parent AND has no children of its own.
+--- Roots (no parent) and mid-level parents (have parent but also have
+--- children) stay visible as top-level cards. Leaves are reachable via
+--- tree expansion on their parent.
+---
+--- `sub_issue_counts` indicates which issues have children. When omitted
+--- (e.g. the cached-warm Board:open fallback path), the filter is a no-op
+--- so a mid-level parent isn't accidentally hidden as a leaf — populate's
+--- async barrier will repaint with the real counts shortly.
 ---@param cols table[] Column list from build_column_list
 ---@param parent_map table<integer, integer>|nil
+---@param sub_issue_counts table<integer, {total: integer, completed: integer}>|nil
 ---@return boolean filtered_any True if at least one issue was removed
-local function filter_sub_issues_in_place(cols, parent_map)
+local function filter_sub_issues_in_place(cols, parent_map, sub_issue_counts)
   if not parent_map or vim.tbl_isempty(parent_map) then
+    return false
+  end
+  if not sub_issue_counts then
     return false
   end
   local filtered_any = false
@@ -245,7 +258,9 @@ local function filter_sub_issues_in_place(cols, parent_map)
     local original_count = #col.issues
     local filtered = {}
     for _, issue in ipairs(col.issues) do
-      if not parent_map[issue.number] then
+      local has_parent = parent_map[issue.number] ~= nil
+      local has_children = sub_issue_counts[issue.number] ~= nil
+      if not has_parent or has_children then
         table.insert(filtered, issue)
       end
     end
@@ -689,6 +704,97 @@ function Board:_setup_or_update_navigation()
   self.navigation:highlight_current()
 end
 
+--- Inject parents referenced by fetched children that are not themselves
+--- in the fetched data. Mutates `data.columns[i].issues` in place by
+--- appending each newly-fetched parent into the column whose okuban:
+--- label it carries. Extends `parent_map` and `counts` with any new
+--- parent/child or count info discovered during the fetch, then recurses
+--- so transitive ancestors are pulled in too.
+---
+--- Bounded depth: stops after MAX_DEPTH passes to defend against
+--- pathological GitHub data (cycles, runaway hierarchies).
+---@param data table Board data from api.fetch_all_columns
+---@param parent_map table<integer, integer> Mutated; new entries added
+---@param counts table<integer, {total: integer, completed: integer}> Mutated
+---@param callback fun()
+local function inject_missing_parents(data, parent_map, counts, callback)
+  local MAX_DEPTH = 5
+  local depth = 0
+  local label_to_col = {}
+  for col_idx, col in ipairs(data.columns) do
+    if col.label then
+      label_to_col[col.label] = col_idx
+    end
+  end
+
+  local function step()
+    local visible = {}
+    for _, col in ipairs(data.columns) do
+      for _, issue in ipairs(col.issues) do
+        visible[issue.number] = true
+      end
+    end
+    if data.unsorted then
+      for _, issue in ipairs(data.unsorted) do
+        visible[issue.number] = true
+      end
+    end
+
+    local missing = {}
+    for _, parent_num in pairs(parent_map) do
+      if not visible[parent_num] and not missing[parent_num] then
+        missing[parent_num] = true
+      end
+    end
+    local missing_list = {}
+    for num in pairs(missing) do
+      table.insert(missing_list, num)
+    end
+    if #missing_list == 0 or depth >= MAX_DEPTH then
+      -- Re-sort each column so injected parents land in the right position
+      -- per the configured sort (default: updatedAt desc).
+      local api_labels = require("okuban.api_labels")
+      if api_labels.sort_issues then
+        for _, col in ipairs(data.columns) do
+          api_labels.sort_issues(col.issues)
+        end
+      end
+      callback()
+      return
+    end
+    depth = depth + 1
+
+    local api = require("okuban.api")
+    api.fetch_issue_details(missing_list, function(parents, new_parents, new_counts)
+      for _, parent in ipairs(parents) do
+        local placed = false
+        for _, label in ipairs(parent.labels or {}) do
+          local target = label_to_col[label.name]
+          if target and data.columns[target] then
+            table.insert(data.columns[target].issues, parent)
+            placed = true
+            break
+          end
+        end
+        -- Parent with no matching okuban: label is intentionally not
+        -- injected: it would have no home column. Its children remain
+        -- hidden by the leaf filter and unreachable from the board,
+        -- which is the user's responsibility to fix (label the parent).
+        local _ = placed
+      end
+      for k, v in pairs(new_parents) do
+        parent_map[k] = v
+      end
+      for k, v in pairs(new_counts) do
+        counts[k] = v
+      end
+      step()
+    end)
+  end
+
+  step()
+end
+
 --- Populate existing loading windows with real data in-place.
 --- Waits for ALL async data fetches (worktree enrichment + sub-issue
 --- metadata) before painting so the user sees one fully-formed render
@@ -765,9 +871,9 @@ function Board:populate(data, on_painted)
     self:_stop_loading_animation()
 
     local pm = fresh_parent_map or cached_parent_map or {}
-    local final_cols = build_column_list(data)
-    filter_sub_issues_in_place(final_cols, pm)
     self.sub_issue_counts = fresh_counts or self.sub_issue_counts or {}
+    local final_cols = build_column_list(data)
+    filter_sub_issues_in_place(final_cols, pm, self.sub_issue_counts)
     self.worktree_map = enriched_wt_map or wt_map
 
     self:_paint_columns(final_cols, layout, self.worktree_map, claude.get_all_sessions(), self.sub_issue_counts)
@@ -803,7 +909,16 @@ function Board:populate(data, on_painted)
     api.fetch_sub_issue_counts(all_numbers, function(counts, pm)
       fresh_counts = counts
       fresh_parent_map = pm
-      on_async_done()
+      -- Pull in parents referenced by fetched children that fell outside
+      -- `initial_fetch_limit`. Each newly-injected parent is appended to
+      -- `data.columns[i].issues` based on its okuban: label, so the leaf
+      -- filter has a complete picture of which parents are on the board.
+      inject_missing_parents(data, fresh_parent_map, fresh_counts, function()
+        if self._populate_gen ~= gen then
+          return
+        end
+        on_async_done()
+      end)
     end)
   end
 
@@ -845,10 +960,13 @@ function Board:open(data)
   local sessions = claude.get_all_sessions()
 
   -- Apply cached parent_map filter pre-render (warm path; matches populate).
+  -- Without cached sub_issue_counts the filter is a no-op (it can't tell
+  -- mid-level parents from leaves), so populate's full async barrier path
+  -- will repaint with the correct filter shortly.
   local api_module = require("okuban.api")
   local cached_parent_map = (api_module.get_cached_parent_map and api_module.get_cached_parent_map()) or nil
   if cached_parent_map and not vim.tbl_isempty(cached_parent_map) then
-    filter_sub_issues_in_place(cols, cached_parent_map)
+    filter_sub_issues_in_place(cols, cached_parent_map, self.sub_issue_counts)
   end
 
   for i, col in ipairs(cols) do
@@ -1151,5 +1269,7 @@ function Board.close_instance()
 end
 
 Board._build_column_list = build_column_list
+Board._filter_sub_issues_in_place = filter_sub_issues_in_place
+Board._inject_missing_parents = inject_missing_parents
 
 return Board

--- a/tests/test_board_layout_spec.lua
+++ b/tests/test_board_layout_spec.lua
@@ -579,5 +579,143 @@ describe("okuban.ui.board layout", function()
       assert.equals(1, #data.columns[1].issues)
       assert.equals(11, data.columns[1].issues[1].number)
     end)
+
+    it("places multi-label parent in the first matching column (config order)", function()
+      -- Real tactus case: an issue carries both okuban:backlog AND
+      -- okuban:in-progress. Placement must follow data.columns order
+      -- (= user config order) so it is deterministic regardless of how
+      -- GitHub returns the labels array.
+      local data = {
+        columns = {
+          { label = "okuban:backlog", name = "Backlog", issues = {} },
+          { label = "okuban:todo", name = "Todo", issues = {} },
+          { label = "okuban:in-progress", name = "In Progress", issues = { { number = 30 } } },
+        },
+      }
+      local parent_map = { [30] = 4 }
+      local counts = {}
+
+      local restore = mock_api({
+        {
+          issues = {
+            {
+              number = 4,
+              title = "Epic with both labels",
+              -- Labels intentionally listed in in-progress-first order.
+              labels = { { name = "okuban:in-progress" }, { name = "okuban:backlog" } },
+            },
+          },
+          parents = {},
+          counts = { [4] = { total = 1, completed = 0 } },
+        },
+      })
+      local done = false
+      Board._inject_missing_parents(data, parent_map, counts, function()
+        done = true
+      end)
+      restore()
+
+      assert.is_true(done)
+      -- Should land in Backlog (col 1) because it is earlier in config order
+      -- than In Progress (col 3), even though the labels array put
+      -- in-progress first.
+      assert.equals(1, #data.columns[1].issues)
+      assert.equals(4, data.columns[1].issues[1].number)
+      -- Not placed twice.
+      assert.equals(0, #data.columns[2].issues)
+      assert.equals(1, #data.columns[3].issues)
+      assert.equals(30, data.columns[3].issues[1].number)
+    end)
+
+    it("respects MAX_DEPTH cap to defend against cycles or runaway hierarchies", function()
+      -- Each step uncovers one more missing parent, chained infinitely.
+      -- After MAX_DEPTH=5 iterations the function must finalize anyway.
+      local data = {
+        columns = {
+          { label = "okuban:backlog", name = "Backlog", issues = { { number = 100 } } },
+        },
+      }
+      local parent_map = { [100] = 99 }
+      local counts = {}
+
+      local call_count = 0
+      local original_require = require
+      _G.require = function(mod)
+        if mod == "okuban.api" then
+          return {
+            fetch_issue_details = function(_, cb)
+              call_count = call_count + 1
+              -- Each fetched parent points to a new "next" parent.
+              local next_num = 99 - call_count
+              cb({
+                {
+                  number = 100 - call_count,
+                  title = "depth " .. call_count,
+                  labels = { { name = "okuban:backlog" } },
+                },
+              }, { [100 - call_count] = next_num }, {})
+            end,
+          }
+        end
+        if mod == "okuban.api_labels" then
+          return { sort_issues = function() end }
+        end
+        return original_require(mod)
+      end
+
+      local done = false
+      Board._inject_missing_parents(data, parent_map, counts, function()
+        done = true
+      end)
+      _G.require = original_require
+
+      assert.is_true(done)
+      -- MAX_DEPTH is 5 — assert we did not run away.
+      assert.is_true(call_count <= 5, "depth cap should bound calls, got " .. call_count)
+    end)
+
+    it("respects should_cancel and short-circuits the chain", function()
+      local data = {
+        columns = {
+          { label = "okuban:backlog", name = "Backlog", issues = { { number = 11 } } },
+        },
+      }
+      local parent_map = { [11] = 4 }
+      local counts = {}
+
+      local fetch_calls = 0
+      local original_require = require
+      _G.require = function(mod)
+        if mod == "okuban.api" then
+          return {
+            fetch_issue_details = function(_, cb)
+              fetch_calls = fetch_calls + 1
+              cb({
+                { number = 4, title = "Root", labels = { { name = "okuban:backlog" } } },
+              }, {}, {})
+            end,
+          }
+        end
+        if mod == "okuban.api_labels" then
+          return { sort_issues = function() end }
+        end
+        return original_require(mod)
+      end
+
+      local done = false
+      -- should_cancel returns true immediately → no fetches should run.
+      Board._inject_missing_parents(data, parent_map, counts, function()
+        done = true
+      end, function()
+        return true
+      end)
+      _G.require = original_require
+
+      assert.is_true(done)
+      assert.equals(0, fetch_calls)
+      -- Data unchanged.
+      assert.equals(1, #data.columns[1].issues)
+      assert.equals(11, data.columns[1].issues[1].number)
+    end)
   end)
 end)

--- a/tests/test_board_layout_spec.lua
+++ b/tests/test_board_layout_spec.lua
@@ -337,4 +337,247 @@ describe("okuban.ui.board layout", function()
       assert.is_true(cols[1].has_more)
     end)
   end)
+
+  describe("_filter_sub_issues_in_place", function()
+    -- Rule: drop iff `parent_map[n]` is set AND `sub_issue_counts[n]` is not
+    -- set. Keep roots and mid-level parents; drop only leaves. (Fixes #160)
+    it("drops a leaf sub-issue (has parent, no children)", function()
+      local cols = {
+        { name = "Backlog", issues = { { number = 7 }, { number = 28 } } },
+      }
+      local parent_map = { [7] = 4, [28] = 7 }
+      local counts = { [7] = { total = 8, completed = 0 } } -- #28 is a leaf
+      local changed = Board._filter_sub_issues_in_place(cols, parent_map, counts)
+      assert.is_true(changed)
+      assert.equals(1, #cols[1].issues)
+      assert.equals(7, cols[1].issues[1].number)
+    end)
+
+    it("keeps a mid-level parent (has parent AND children)", function()
+      local cols = {
+        { name = "In Progress", issues = { { number = 7 } } },
+      }
+      local parent_map = { [7] = 4 } -- #7 has parent #4
+      local counts = { [7] = { total = 8, completed = 0 } } -- #7 has 8 children
+      local changed = Board._filter_sub_issues_in_place(cols, parent_map, counts)
+      assert.is_false(changed)
+      assert.equals(1, #cols[1].issues)
+    end)
+
+    it("keeps a root issue (no parent)", function()
+      local cols = {
+        { name = "Backlog", issues = { { number = 4 } } },
+      }
+      local parent_map = {} -- #4 has no parent
+      local counts = { [4] = { total = 8, completed = 0 } }
+      local changed = Board._filter_sub_issues_in_place(cols, parent_map, counts)
+      assert.is_false(changed)
+      assert.equals(1, #cols[1].issues)
+    end)
+
+    it("tactus-shape filter: roots + mid-level kept, leaves dropped", function()
+      -- #4 root (children), #7 mid (parent=#4, children=8), #28-#35 leaves
+      -- (parent=#7). Backlog also has #11, #12 leaves (parent=#4) and #4.
+      local cols = {
+        {
+          name = "Backlog",
+          issues = {
+            { number = 4 },
+            { number = 11 },
+            { number = 12 },
+            { number = 28 },
+            { number = 35 },
+          },
+        },
+        { name = "In Progress", issues = { { number = 7 }, { number = 30 } } },
+      }
+      local parent_map = {
+        [7] = 4,
+        [11] = 4,
+        [12] = 4,
+        [28] = 7,
+        [30] = 7,
+        [35] = 7,
+      }
+      local counts = {
+        [4] = { total = 8, completed = 0 },
+        [7] = { total = 8, completed = 0 },
+      }
+      Board._filter_sub_issues_in_place(cols, parent_map, counts)
+      assert.equals(1, #cols[1].issues)
+      assert.equals(4, cols[1].issues[1].number)
+      assert.equals(1, #cols[2].issues)
+      assert.equals(7, cols[2].issues[1].number)
+    end)
+
+    it("no-op when sub_issue_counts is nil (warm cache fallback)", function()
+      -- Cached Board:open path may run before counts are available; the
+      -- filter must NOT drop mid-level parents based on parent_map alone.
+      local cols = {
+        { name = "In Progress", issues = { { number = 7 } } },
+      }
+      local parent_map = { [7] = 4 }
+      local changed = Board._filter_sub_issues_in_place(cols, parent_map, nil)
+      assert.is_false(changed)
+      assert.equals(1, #cols[1].issues)
+    end)
+
+    it("no-op when parent_map is nil or empty", function()
+      local cols = {
+        { name = "Backlog", issues = { { number = 1 }, { number = 2 } } },
+      }
+      assert.is_false(Board._filter_sub_issues_in_place(cols, nil, {}))
+      assert.equals(2, #cols[1].issues)
+      assert.is_false(Board._filter_sub_issues_in_place(cols, {}, {}))
+      assert.equals(2, #cols[1].issues)
+    end)
+  end)
+
+  describe("_inject_missing_parents", function()
+    local function mock_api(fetch_responses)
+      local original_require = require
+      local idx = 0
+      _G.require = function(mod)
+        if mod == "okuban.api" then
+          return {
+            fetch_issue_details = function(_, cb)
+              idx = idx + 1
+              local resp = fetch_responses[idx] or { issues = {}, parents = {}, counts = {} }
+              cb(resp.issues, resp.parents, resp.counts)
+            end,
+          }
+        end
+        if mod == "okuban.api_labels" then
+          return { sort_issues = function() end }
+        end
+        return original_require(mod)
+      end
+      return function()
+        _G.require = original_require
+      end
+    end
+
+    it("injects a missing parent into its labeled column", function()
+      local data = {
+        columns = {
+          { label = "okuban:backlog", name = "Backlog", issues = { { number = 11 }, { number = 12 } } },
+        },
+      }
+      local parent_map = { [11] = 4, [12] = 4 }
+      local counts = {}
+
+      local restore = mock_api({
+        {
+          issues = { { number = 4, title = "Skeleton spike", labels = { { name = "okuban:backlog" } } } },
+          parents = {},
+          counts = { [4] = { total = 8, completed = 0 } },
+        },
+      })
+      local done = false
+      Board._inject_missing_parents(data, parent_map, counts, function()
+        done = true
+      end)
+      restore()
+
+      assert.is_true(done)
+      assert.equals(3, #data.columns[1].issues)
+      local found = false
+      for _, issue in ipairs(data.columns[1].issues) do
+        if issue.number == 4 then
+          found = true
+        end
+      end
+      assert.is_true(found)
+      assert.is_not_nil(counts[4])
+      assert.equals(8, counts[4].total)
+    end)
+
+    it("recursively pulls in grandparents", function()
+      local data = {
+        columns = {
+          { label = "okuban:backlog", name = "Backlog", issues = { { number = 28 } } },
+          { label = "okuban:in-progress", name = "In Progress", issues = {} },
+        },
+      }
+      local parent_map = { [28] = 7 }
+      local counts = {}
+
+      local restore = mock_api({
+        {
+          issues = { { number = 7, title = "Mid", labels = { { name = "okuban:in-progress" } } } },
+          parents = { [7] = 4 },
+          counts = { [7] = { total = 8, completed = 0 } },
+        },
+        {
+          issues = { { number = 4, title = "Root", labels = { { name = "okuban:backlog" } } } },
+          parents = {},
+          counts = { [4] = { total = 8, completed = 0 } },
+        },
+      })
+      local done = false
+      Board._inject_missing_parents(data, parent_map, counts, function()
+        done = true
+      end)
+      restore()
+
+      assert.is_true(done)
+      local nums_backlog = {}
+      for _, issue in ipairs(data.columns[1].issues) do
+        nums_backlog[issue.number] = true
+      end
+      assert.is_true(nums_backlog[4])
+      assert.is_true(nums_backlog[28])
+      local nums_in_progress = {}
+      for _, issue in ipairs(data.columns[2].issues) do
+        nums_in_progress[issue.number] = true
+      end
+      assert.is_true(nums_in_progress[7])
+      assert.equals(4, parent_map[7])
+    end)
+
+    it("does nothing when no parents are missing", function()
+      local data = {
+        columns = {
+          { label = "okuban:backlog", name = "Backlog", issues = { { number = 4 }, { number = 11 } } },
+        },
+      }
+      local parent_map = { [11] = 4 }
+      local counts = { [4] = { total = 1, completed = 0 } }
+      local restore = mock_api({})
+      local done = false
+      Board._inject_missing_parents(data, parent_map, counts, function()
+        done = true
+      end)
+      restore()
+
+      assert.is_true(done)
+      assert.equals(2, #data.columns[1].issues)
+    end)
+
+    it("skips parents whose label is not in any configured column", function()
+      local data = {
+        columns = {
+          { label = "okuban:backlog", name = "Backlog", issues = { { number = 11 } } },
+        },
+      }
+      local parent_map = { [11] = 4 }
+      local counts = {}
+      local restore = mock_api({
+        {
+          issues = { { number = 4, title = "No kanban label", labels = { { name = "type: bug" } } } },
+          parents = {},
+          counts = { [4] = { total = 1, completed = 0 } },
+        },
+      })
+      local done = false
+      Board._inject_missing_parents(data, parent_map, counts, function()
+        done = true
+      end)
+      restore()
+
+      assert.is_true(done)
+      assert.equals(1, #data.columns[1].issues)
+      assert.equals(11, data.columns[1].issues[1].number)
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary

Implements the tree-only sub-issue design the user clarified after the orphan-promotion approach (previous commit on this branch) was rejected:

- **Filter rule**: drop iff `parent_map[n]` is set AND `sub_issue_counts[n]` is not set. Roots and mid-level parents stay; only leaves are hidden.
- **Auto-fetch missing parents**: after `fetch_sub_issue_counts`, scan for parents referenced by fetched children that aren't in the fetched data; batch-fetch each via GraphQL and inject into the column matching its `okuban:` label. Recurses up to depth 5 for grandparents.

Pre-existing tree expansion (#55 / #70) and sub-issue count badges (#54 / #61) cover the rest — pressing `<CR>` on a top-level card with children opens an inline tree.

## Behaviour change

For a 3-level repo (e.g. `khwerhahn/tactus`: epic #4 → milestone #7 → tasks #28-#35):

| Issue | Has parent | Has children | Action |
|---|---|---|---|
| #4 (root) | no | yes (8) | KEEP, badge `(8)` |
| #5, #6, #7 (mid) | yes (=#4) | yes (5 / 5 / 8) | KEEP, badges |
| #8-#12 (leaves under #4) | yes | no | DROP — tree-only |
| #16-#20 (leaves under #5) | yes | no | DROP |
| #28-#35 (leaves under #7) | yes | no | DROP |

Default Backlog of tactus, before this PR: 10 unfiltered leaves OR empty board (depending on which earlier bug was masking). After this PR: just `#4` with badge `(8)`. Press Enter on `#4` to see #5, #6, #7, #8, #9, #10, #11, #12 in tree.

## Why parent-fetching is needed

With `initial_fetch_limit = 10` + `sort = updated/desc`, epics like `#4` fall outside the fetch window for Backlog (the leaves were updated more recently than the epic). Without injecting `#4` into the fetched data the filter would correctly drop the leaves but Backlog would render empty. The fetch step ensures every parent referenced by a visible child is itself visible, so the filter has a complete picture and tree expansion is always reachable.

## Implementation

- `lua/okuban/api_labels.lua`: new `M.fetch_issue_details(numbers, callback)` — batched GraphQL alias query with `parent { number }`, `subIssuesSummary`, `labels`, `assignees`. Returns issues in gh-CLI shape plus extracted parent/count maps.
- `lua/okuban/api.lua`: wires `fetch_issue_details` through the api facade (label mode only; no-op in project mode).
- `lua/okuban/ui/board.lua`:
  - `filter_sub_issues_in_place` signature gains `sub_issue_counts` parameter. Filter is a no-op when counts are absent (warm `Board:open` cache path) to avoid hiding mid-level parents.
  - New `inject_missing_parents(data, parent_map, counts, cb)` — iterative, mutates `data.columns[i].issues` in place, re-sorts each column after injection, depth-capped at 5.
  - `Board:populate` calls `inject_missing_parents` between `fetch_sub_issue_counts` and the async barrier so the paint sees the complete dataset.

## Test plan

- [x] `make check` — 0 warnings, 0 failures across all 21 test files.
- [x] 10 new regression tests in `tests/test_board_layout_spec.lua`:
  - `_filter_sub_issues_in_place`: leaf drop, mid-parent keep, root keep, tactus multi-column shape, nil-counts no-op, nil/empty parent_map no-op
  - `_inject_missing_parents`: single parent injection, recursive grandparent fetch, no-op when nothing missing, unlabeled-parent skip
- [ ] CI: Lint, Test (stable), Test (nightly)
- [ ] Manual: open board against `khwerhahn/tactus` from a fresh Neovim — Backlog shows `#4 (8)`, Todo empty, In Progress `#7 (8)`, Review `#5 (5)` + `#6 (5)`. Enter on `#4` expands inline tree showing #5–#12.

Replaces the previous orphan-promotion commit on this branch (force-pushed).

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)